### PR TITLE
Logging and request IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ generate-manifest:
 
 	@jinja2 --strict manifest.yml.j2 \
 	    -D environment=${CF_SPACE} --format=yaml \
-	    <(${DECRYPT_CMD} ${NOTIFY_CREDENTIALS}/credentials/${CF_SPACE}/document-download/paas-environment.gpg)
+	    <(${DECRYPT_CMD} ${NOTIFY_CREDENTIALS}/credentials/${CF_SPACE}/document-download/paas-environment.gpg) 2>&1
 
 .PHONY: cf-push
 cf-push:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,19 @@ test:
 .PHONY: preview
 preview:
 	$(eval export CF_SPACE=preview)
+	$(eval export DNS_NAME=download.notify.works)
+	cf target -s ${CF_SPACE}
+
+.PHONY: staging
+staging:
+	$(eval export CF_SPACE=staging)
+	$(eval export DNS_NAME=download.staging-notify.works)
+	cf target -s ${CF_SPACE}
+
+.PHONY: production
+production:
+	$(eval export CF_SPACE=production)
+	$(eval export DNS_NAME=download.notifications.service.gov.uk)
 	cf target -s ${CF_SPACE}
 
 .PHONY: generate-manifest
@@ -59,6 +72,12 @@ cf-rollback: ## Rollbacks the app to the previous release
 	@[ $$(cf curl /v2/apps/`cf app --guid ${CF_APP}-rollback` | jq -r ".entity.state") = "STARTED" ] || (echo "Error: rollback is not possible because ${CF_APP}-rollback is not in a started state" && exit 1)
 	cf delete -f ${CF_APP} || true
 	cf rename ${CF_APP}-rollback ${CF_APP}
+
+.PHONY: cf-create-cdn-route
+cf-create-cdn-route:
+	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
+	$(if ${DNS_NAME},,$(error Must specify DNS_NAME))
+	cf create-service cdn-route cdn-route document-download-cdn-route -c '{"domain": "${DNS_NAME}"}'
 
 .PHONY: cf-login
 cf-login: ## Log in to Cloud Foundry

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,7 @@
 from flask import Flask
 
+from notifications_utils import logging, request_helper
+
 from app.config import configs
 from app.utils.store import DocumentStore
 
@@ -10,8 +12,11 @@ from .upload.views import upload_blueprint
 
 
 def create_app(environment):
-    application = Flask('api')
+    application = Flask('app')
     application.config.from_object(configs[environment])
+
+    request_helper.init_app(application)
+    logging.init_app(application)
 
     document_store.init_app(application)
 

--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,9 @@ class Config(metaclass=MetaFlaskEnv):
 
     DOCUMENTS_BUCKET = None
 
+    NOTIFY_APP_NAME = None
+    NOTIFY_LOG_PATH = None
+
 
 class Test(Config):
     DEBUG = True

--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,8 @@ class Config(metaclass=MetaFlaskEnv):
 
     DOCUMENTS_BUCKET = None
 
+    PUBLIC_HOSTNAME = None
+
     NOTIFY_APP_NAME = None
     NOTIFY_LOG_PATH = None
 

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, make_response, request, send_file
+from flask import Blueprint, current_app, jsonify, make_response, request, send_file
 
 from app import document_store
 
@@ -15,6 +15,13 @@ def download_document(service_id, document_id):
     try:
         document = document_store.get(service_id, document_id, request.args.get('key'))
     except DocumentStoreError as e:
+        current_app.logger.info(
+            'Failed to download document: {}'.format(e),
+            extra={
+                'service_id': service_id,
+                'document_id': document_id,
+            }
+        )
         return jsonify(error=str(e)), 400
 
     response = make_response(send_file(document['body'], mimetype=document['mimetype']))

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request, url_for
 
 from app import document_store
 from app.utils.authentication import check_auth
+from app.utils.urls import get_document_download_url
 
 upload_blueprint = Blueprint('upload', __name__, url_prefix='')
 upload_blueprint.before_request(check_auth)
@@ -18,12 +19,10 @@ def upload_document(service_id):
         status='ok',
         document={
             'id': document['id'],
-            'url': url_for(
-                'download.download_document',
+            'url': get_document_download_url(
                 service_id=service_id,
                 document_id=document['id'],
                 key=document['encryption_key'],
-                _external=True
             )
         }
     ), 201

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -1,0 +1,20 @@
+from urllib.parse import urlsplit, urlunsplit
+from flask import current_app, url_for
+
+
+def get_document_download_url(service_id, document_id, key):
+    url = url_for(
+        'download.download_document',
+        service_id=service_id,
+        document_id=document_id,
+        key=key,
+        _external=True
+    )
+
+    if current_app.config['PUBLIC_HOSTNAME']:
+        url = urlunsplit(urlsplit(url)._replace(
+            scheme="https",
+            netloc=current_app.config['PUBLIC_HOSTNAME']
+        ))
+
+    return url

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -21,6 +21,8 @@ applications:
     FLASK_APP: application.py
     ENVIRONMENT: {{ environment }}
 
+    PUBLIC_HOSTNAME: {{ hostname }}
+
     NOTIFY_APP_NAME: document-download-api
     NOTIFY_LOG_PATH: /home/vcap/logs/app.log
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -8,8 +8,14 @@ applications:
   buildpack: python_buildpack
   command: scripts/run_app_paas.sh gunicorn -w 4 -k eventlet -b 0.0.0.0:$PORT application --worker-connections 1000 --error-logfile /home/vcap/logs/gunicorn_error.log
 
+  {% set hostname={
+    "preview": "download.notify.works",
+    "staging": "download.staging-notify.works",
+    "production": "download.notifications.service.gov.uk"
+  }[environment] %}
   routes:
     - route: document-download-api-{{ environment }}.cloudapps.digital
+    - route: {{ hostname }}
 
   env:
     FLASK_APP: application.py

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -6,7 +6,7 @@ applications:
   memory: 512M
 
   buildpack: python_buildpack
-  command: gunicorn -w 4 -k eventlet -b 0.0.0.0:$PORT application --worker-connections 1000
+  command: scripts/run_app_paas.sh gunicorn -w 4 -k eventlet -b 0.0.0.0:$PORT application --worker-connections 1000 --error-logfile /home/vcap/logs/gunicorn_error.log
 
   routes:
     - route: document-download-api-{{ environment }}.cloudapps.digital
@@ -14,6 +14,9 @@ applications:
   env:
     FLASK_APP: application.py
     ENVIRONMENT: {{ environment }}
+
+    NOTIFY_APP_NAME: document-download-api
+    NOTIFY_LOG_PATH: /home/vcap/logs/app.log
 
     AUTH_TOKENS: {{ AUTH_TOKENS }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,12 @@ Flask-Env==1.0.1
 
 boto3==1.5.22
 
+git+https://github.com/alphagov/notifications-utils.git@25.1.0#egg=notifications-utils==25.1.0
+
+# PaaS
+
 gunicorn==19.7.1
 eventlet==0.22
+
+awscli>=1.11,<1.12
+awscli-cwlogs>=1.4,<1.5

--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+TERMINATE_TIMEOUT=30
+
+function check_params {
+  if [ -z "${NOTIFY_APP_NAME}" ]; then
+    echo "You must set NOTIFY_APP_NAME"
+    exit 1
+  fi
+
+  if [ -z "${CW_APP_NAME}" ]; then
+    CW_APP_NAME=${NOTIFY_APP_NAME}
+  fi
+}
+
+function configure_aws_logs {
+  # create files so that aws logs agent doesn't complain
+  touch /home/vcap/logs/gunicorn_error.log
+  touch /home/vcap/logs/app.log.json
+
+  aws configure set plugins.cwlogs cwlogs
+
+  cat > /home/vcap/app/awslogs.conf << EOF
+[general]
+state_file = /home/vcap/logs/awslogs-state
+
+[/home/vcap/logs/app.log]
+file = /home/vcap/logs/app.log.json
+log_group_name = paas-${CW_APP_NAME}-application
+log_stream_name = {hostname}
+
+[/home/vcap/logs/gunicorn_error.log]
+file = /home/vcap/logs/gunicorn_error.log
+log_group_name = paas-${CW_APP_NAME}-gunicorn
+log_stream_name = {hostname}
+EOF
+}
+
+function on_exit {
+  echo "Terminating application process with pid ${APP_PID}"
+  kill ${APP_PID} || true
+  n=0
+  while (kill -0 ${APP_PID} 2&>/dev/null); do
+    echo "Application is still running.."
+    sleep 1
+    let n=n+1
+    if [ "$n" -ge "$TERMINATE_TIMEOUT" ]; then
+      echo "Timeout reached, killing process with pid ${APP_PID}"
+      kill -9 ${APP_PID} || true
+      break
+    fi
+  done
+  echo "Terminating remaining subprocesses.."
+  kill 0
+}
+
+function start_application {
+  exec "$@" &
+  APP_PID=`jobs -p`
+  echo "Application process pid: ${APP_PID}"
+}
+
+function start_aws_logs_agent {
+  exec aws logs push --region eu-west-1 --config-file /home/vcap/app/awslogs.conf &
+  AWSLOGS_AGENT_PID=$!
+  echo "AWS logs agent pid: ${AWSLOGS_AGENT_PID}"
+}
+
+function run {
+  while true; do
+    kill -0 ${APP_PID} 2&>/dev/null || break
+    kill -0 ${AWSLOGS_AGENT_PID} 2&>/dev/null || start_aws_logs_agent
+    sleep 1
+  done
+}
+
+echo "Run script pid: $$"
+
+check_params
+
+trap "on_exit" EXIT
+
+configure_aws_logs
+
+# The application has to start first!
+start_application "$@"
+
+start_aws_logs_agent
+
+run

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -29,7 +29,8 @@ def test_document_download(client, store):
         'Cache-Control': mock.ANY,
         'Expires': mock.ANY,
         'Content-Length': '100',
-        'Content-Type': 'application/pdf'
+        'Content-Type': 'application/pdf',
+        'NotifyRequestID': mock.ANY,
     }
 
 

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -1,0 +1,20 @@
+from tests.conftest import set_config
+
+from app.utils.urls import get_document_download_url
+
+
+def test_download_url_returns_url_for(app, mocker):
+    mocker.patch('app.utils.urls.url_for', return_value='http://localhost:7000/path?key=value')
+
+    assert get_document_download_url(
+        service_id='service-id', document_id='document-id', key='key'
+    ) == 'http://localhost:7000/path?key=value'
+
+
+def test_download_url_uses_public_hostname_when_set(app, mocker):
+    mocker.patch('app.utils.urls.url_for', return_value='http://localhost:7000/path?key=value')
+
+    with set_config(app, PUBLIC_HOSTNAME='download.example.com'):
+        assert get_document_download_url(
+            service_id='service-id', document_id='document-id', key='key'
+        ) == 'https://download.example.com/path?key=value'


### PR DESCRIPTION
### Fail cf-push if secret variables failed to decrypt

If manifest template is missing variables jinja-cli will output an exception to stderr and exit without printing anything to stdout.

This makes `cf push` run with an empty manifest, which it treats as a valid call so it proceeds to deploy an app without any route or environment variable configuration.

To avoid this we redirect stderr to sdout when generating a manifest, so if an exception happens it is written to the manifest and since it's invalid YAML `cf push` will fail the release right away.

The problem with this approach is that the exception no longer appears in the command output or CI logs, so it's not obvious what is wrong with the manifest generation.

An alternative approach would be to not specify application name in the `cf push` command, making it invalid to use with an empty manifest. This works for regular `cf push` since it will deploy all apps listed in the manifest. However it doesn't fit with our zero-downtime release task, since it requires apps to be pushed individually and has to name each deployed app in advance.

### Add logging and request id helpers and awslogs run script

Uses notifications-utils to configure logging and request IDs. Adds a run_app_paas script from notifications-api used to start the awslogs alongside the application server.

### Bind the download. Notify subdomain route to the app

Adds download.* to the list of app routes. Subdomain is registered with a cdn-route service created in each PaaS space, so requests are going through CloudFront instance and document responses are cached by AWS.

### Always return the download link containing the public subdomain

`url_for` generates a link based on the request Host header. This means that if the app is accessed using the cloudapps.digital PaaS subdomain it will return a download link based on that subdomain.

Since we want to always return links with the public download.* domain, to avoid any potential errors we could either:

1. Only allow upload access to the app through the download.* domain, making all requests (not just download requests go through CloudFront)

2. Always use the download.* domain in the generated link, overriding request Host value.

While first approach would be easier to implement and doesn't require a helper function to be used everywhere the link is returned it would prevent us from moving the upload API from the public domain (eg to reduce any latency added by CloudFront or to move it to a separate PaaS app).
