### PR TITLE
Prometheus metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,30 +48,31 @@ generate-manifest:
 .PHONY: cf-push
 cf-push:
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
-	cf push ${CF_APP} -f <(make -s generate-manifest)
+	cf push ${CF_APP}-${CF_SPACE} -f <(make -s generate-manifest)
 
 .PHONY: cf-deploy
 cf-deploy: ## Deploys the app to Cloud Foundry
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
-	@cf app --guid ${CF_APP} || exit 1
-	cf rename ${CF_APP} ${CF_APP}-rollback
-	cf push ${CF_APP} -f <(make -s generate-manifest)
-	cf scale -i $$(cf curl /v2/apps/$$(cf app --guid ${CF_APP}-rollback) | jq -r ".entity.instances" 2>/dev/null || echo "1") ${CF_APP}
-	cf stop ${CF_APP}-rollback
+	@cf app --guid ${CF_APP}-${CF_SPACE} || exit 1
+	cf rename ${CF_APP}-${CF_SPACE} ${CF_APP}-${CF_SPACE}-rollback
+	cf push ${CF_APP}-${CF_SPACE} -f <(make -s generate-manifest)
+	cf scale -i $$(cf curl /v2/apps/$$(cf app --guid ${CF_APP}-${CF_SPACE}-rollback) | jq -r ".entity.instances" 2>/dev/null || echo "1") ${CF_APP}-${CF_SPACE}
+	cf stop ${CF_APP}-${CF_SPACE}-rollback
 	# sleep for 10 seconds to try and make sure that all worker threads (either web api or celery) have finished before we delete
 	sleep 10
 
 	# get the new GUID, and find all crash events for that. If there were any crashes we will abort the deploy.
-	[ $$(cf curl "/v2/events?q=type:app.crash&q=actee:$$(cf app --guid ${CF_APP})" | jq ".total_results") -eq 0 ]
-	cf delete -f ${CF_APP}-rollback
+	[ $$(cf curl "/v2/events?q=type:app.crash&q=actee:$$(cf app --guid ${CF_APP}-${CF_SPACE})" | jq ".total_results") -eq 0 ]
+	cf delete -f ${CF_APP}-${CF_SPACE}-rollback
 
 .PHONY: cf-rollback
 cf-rollback: ## Rollbacks the app to the previous release
 	$(if ${CF_APP},,$(error Must specify CF_APP))
-	@cf app --guid ${CF_APP}-rollback || exit 1
-	@[ $$(cf curl /v2/apps/`cf app --guid ${CF_APP}-rollback` | jq -r ".entity.state") = "STARTED" ] || (echo "Error: rollback is not possible because ${CF_APP}-rollback is not in a started state" && exit 1)
-	cf delete -f ${CF_APP} || true
-	cf rename ${CF_APP}-rollback ${CF_APP}
+	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
+	@cf app --guid ${CF_APP}-${CF_SPACE}-rollback || exit 1
+	@[ $$(cf curl /v2/apps/`cf app --guid ${CF_APP}-${CF_SPACE}-rollback` | jq -r ".entity.state") = "STARTED" ] || (echo "Error: rollback is not possible because ${CF_APP}-${CF_SPACE}-rollback is not in a started state" && exit 1)
+	cf delete -f ${CF_APP}-${CF_SPACE} || true
+	cf rename ${CF_APP}-${CF_SPACE}-rollback ${CF_APP}-${CF_SPACE}
 
 .PHONY: cf-create-cdn-route
 cf-create-cdn-route:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,13 @@
 from flask import Flask
 
 from notifications_utils import logging, request_helper
+from gds_metrics import GDSMetrics
 
 from app.config import configs
 from app.utils.store import DocumentStore
 
-document_store = DocumentStore()
+document_store = DocumentStore() # noqa, has to be imported before views
+metrics = GDSMetrics() # noqa
 
 from .download.views import download_blueprint
 from .upload.views import upload_blueprint
@@ -19,6 +21,7 @@ def create_app(environment):
     logging.init_app(application)
 
     document_store.init_app(application)
+    metrics.init_app(application)
 
     application.register_blueprint(download_blueprint)
     application.register_blueprint(upload_blueprint)

--- a/app/config.py
+++ b/app/config.py
@@ -12,7 +12,7 @@ class Config(metaclass=MetaFlaskEnv):
     PUBLIC_HOSTNAME = None
 
     NOTIFY_APP_NAME = None
-    NOTIFY_LOG_PATH = None
+    NOTIFY_LOG_PATH = 'application.log'
 
 
 class Test(Config):

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,0 +1,12 @@
+import os
+
+from gds_metrics.gunicorn import child_exit # noqa
+
+bind = "0.0.0.0:{}".format(os.getenv("PORT"))
+
+workers = 4
+
+worker_class = "eventlet"
+worker_connections = 1000
+
+errorlog = "/home/vcap/logs/gunicorn_error.log"

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: document-download-api
+- name: document-download-api-{{environment}}
 
   instances: 1
   memory: 512M

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -6,7 +6,7 @@ applications:
   memory: 512M
 
   buildpack: python_buildpack
-  command: scripts/run_app_paas.sh gunicorn -w 4 -k eventlet -b 0.0.0.0:$PORT application --worker-connections 1000 --error-logfile /home/vcap/logs/gunicorn_error.log
+  command: scripts/run_app_paas.sh gunicorn -c gunicorn_config.py application
 
   {% set hostname={
     "preview": "download.notify.works",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,14 +3,13 @@ Flask-Env==1.0.1
 
 boto3==1.5.22
 
-git+https://github.com/alphagov/notifications-utils.git@25.1.0#egg=notifications-utils==25.1.0
+git+https://github.com/alphagov/notifications-utils.git@26.3.0#egg=notifications-utils==26.3.0
 
 # PaaS
 
 gunicorn==19.7.1
 eventlet==0.22
 
-awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ eventlet==0.22
 
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
+
+gds-metrics==0.1.1


### PR DESCRIPTION
### Add Prometheus metrics endpoint with gds-metrics

Adds a /metrics endpoint that collects request times, codes and errors and can be scraped by Prometheus.

This moves gunicorn configuration to a separate file to support prometheus client multiprocess mode.

### Remove CF application to include the current space name

Prometheus service broker expects application route to match <app_name>.cloudapps.digital and currently doesn't support custom routes.

Since we can't use the same route across different spaces we need to add CF_SPACE to the application name (so eg instead of `api` we'll have `api-preview`).

Note: this requires pushing the app with `make cf-push` to each space to create the initial instance (otherwise cf-deploy will fail to find an existing app) and deleting the existing `document-download-api` apps in all spaces afterwards.
