### PR TITLE
Bind Prometheus service broker to the app during release

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -17,6 +17,9 @@ applications:
     - route: document-download-api-{{ environment }}.cloudapps.digital
     - route: {{ hostname }}
 
+  services:
+    - notify-prometheus
+
   env:
     FLASK_APP: application.py
     ENVIRONMENT: {{ environment }}


### PR DESCRIPTION
Adds a make target to create the prometheus service broker and give
it space auditor permissions.

Adds the created service to the document-download-api manifest, so
that it's bound to the new app created by the zero-downtime release
process.