### PR TITLE
Check uploaded document matches one of the allowed file types

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+exclude = venv*,__pycache__,node_modules,cache,migrations,build
+max-complexity = 14
+max-line-length = 120

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN \
 		git \
 		build-essential \
 		zip \
+		libmagic1 \
 	&& echo "Clean up" \
 	&& rm -rf /var/lib/apt/lists/* /tmp/*
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ run:
 test:
 	py.test --cov=app --cov-report=term-missing tests/
 	if [[ ! -z $$COVERALLS_REPO_TOKEN ]]; then coveralls; fi
+	flake8 .
 
 .PHONY: preview
 preview:

--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,10 @@ class Config(metaclass=MetaFlaskEnv):
 
     DOCUMENTS_BUCKET = None
 
+    ALLOWED_MIME_TYPES = [
+        'application/pdf',
+    ]
+
     PUBLIC_HOSTNAME = None
 
     NOTIFY_APP_NAME = None

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,10 @@
+import magic
+
+
+def get_mime_type(document_stream):
+    try:
+        mime_type = magic.from_buffer(document_stream.read(1024), mime=True)
+    finally:
+        document_stream.seek(0)
+
+    return mime_type

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 -r requirements.txt
 
+flake8==3.5.0
+
 pytest==3.4.0
 pytest-mock==1.6.3
 pytest-cov==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ Flask-Env==1.0.1
 
 boto3==1.5.22
 
+python-magic==0.4.15
+
 git+https://github.com/alphagov/notifications-utils.git@26.3.0#egg=notifications-utils==26.3.0
 
 # PaaS


### PR DESCRIPTION
### Check uploaded document matches one of the allowed file types

Identifies the uploaded file type using libmagic and checks if it's included in a list of allowed file types.

This allows us to set the correct mimetype on the S3 object and stops users from uploading unsupported document types.

File identification is based on 'magic patterns' used by `file` command, so while it should identify all valid PDF files as PDF it doesn't guarantee that a file is valid and can be opened by a PDF reader. This should be enough to inform users about our supported document types and prevent accidental uploads of unsupported formats, but doesn't protect against a user trying to send an unsupported file by masking it as one of the allowed types.
