### PR TITLE
Added back the hostname decision block

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -8,6 +8,12 @@ applications:
   buildpack: python_buildpack
   command: scripts/run_app_paas.sh gunicorn -c gunicorn_config.py application
 
+  {% set hostname={
+    "preview": "download.notify.works",
+    "staging": "download.staging-notify.works",
+    "production": "download.notifications.service.gov.uk"
+  }[environment] %}
+
   routes:
     - route: document-download-api-{{ environment }}.cloudapps.digital
 


### PR DESCRIPTION
The hostname is still needed to generate the URL link to send via the notification. So its just the  route that is not needed which gives it its public hostname.