### PR TITLE
Limit uploaded document size to 2Mb

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,8 @@ class Config(metaclass=MetaFlaskEnv):
         'application/pdf',
     ]
 
+    MAX_CONTENT_LENGTH = 2 * 1024 * 1024
+
     PUBLIC_HOSTNAME = None
 
     NOTIFY_APP_NAME = None

--- a/app/upload/__init__.py
+++ b/app/upload/__init__.py
@@ -1,0 +1,1 @@
+from .errors import *  # noqa import errors module to register error handlers

--- a/app/upload/errors.py
+++ b/app/upload/errors.py
@@ -1,0 +1,8 @@
+from flask import jsonify
+
+from .views import upload_blueprint
+
+
+@upload_blueprint.errorhandler(413)
+def request_entity_too_large(error):
+    return jsonify(error="Uploaded document exceeds file size limit"), 413

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -95,6 +95,21 @@ def test_document_upload_unknown_type(client):
     }
 
 
+def test_document_file_size_too_large(client):
+    response = client.post(
+        '/services/12345678-1111-1111-1111-123456789012/documents',
+        content_type='multipart/form-data',
+        data={
+            'document': (io.BytesIO(b'pdf' * 1024 * 1024), 'file.pdf')
+        }
+    )
+
+    assert response.status_code == 413
+    assert json.loads(response.get_data(as_text=True)) == {
+        'error': "Uploaded document exceeds file size limit"
+    }
+
+
 def test_document_upload_no_document(client):
     response = client.post(
         '/services/12345678-1111-1111-1111-123456789012/documents',


### PR DESCRIPTION
Setting MAX_CONTENT_LENGTH configuration option makes Flask return a 413 response when the request Content-Length exceeds the setting value.

We're setting an error handler for 413 status code to return a JSON error response, but since Flask will close the connection before reading the full response (which is the desired behaviour in order to avoid running out of memory/disk space by fetching large requests) depending on the client implementation in might not get displayed.