### PR TITLE
Map the download route to a public domain

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -16,6 +16,7 @@ applications:
 
   routes:
     - route: document-download-api-{{ environment }}.cloudapps.digital
+    - route: {{ hostname }}/services
 
   services:
     - notify-prometheus


### PR DESCRIPTION
Users will download the document file directly from the API to avoid piping the data through the frontend app.

We need to make the download endpoint available through the public service.gov.uk domain. We bind `/services` route to the API, which includes the download route. This means that Document Download frontend will have to avoid using the `/services` prefix for any of its URLs as any requests to them would be routed to the API instead.

API itself isn't restricted to only use `/services` prefix, since other apps can call API endpoints using the .cloudapps.digital subdomain.