### PR TITLE
Replace ENVIRONMENT with FLASK_ENV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CF_APP = document-download-api
 
 .PHONY: run
 run:
-	FLASK_APP=application.py ENVIRONMENT=development flask run -p 7000
+	FLASK_APP=application.py FLASK_ENV=development flask run -p 7000
 
 .PHONY: test
 test:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,9 +14,9 @@ from .download.views import download_blueprint
 from .upload.views import upload_blueprint
 
 
-def create_app(environment):
+def create_app():
     application = Flask('app')
-    application.config.from_object(configs[environment])
+    application.config.from_object(configs[application.env])
 
     request_helper.init_app(application)
     logging.init_app(application)

--- a/application.py
+++ b/application.py
@@ -1,8 +1,6 @@
 ##!/usr/bin/env python
 
-import os
-
 from app import create_app
 
 
-application = create_app(os.environ['ENVIRONMENT'])
+application = create_app()

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -23,7 +23,7 @@ applications:
 
   env:
     FLASK_APP: application.py
-    ENVIRONMENT: {{ environment }}
+    FLASK_ENV: {{ environment }}
 
     FRONTEND_HOSTNAME: {{ hostname }}
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+env =
+    FLASK_ENV=test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 flake8==3.5.0
 
 pytest==3.6.1
+pytest-env==0.6.2
 pytest-mock==1.10.0
 pytest-cov==2.5.1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from app import create_app
 
 @pytest.fixture(scope='session')
 def app():
-    app = create_app('test')
+    app = create_app()
 
     class TestClient(FlaskClient):
         def open(self, *args, **kwargs):


### PR DESCRIPTION
Flask 1.0 introduced ENV config variable (set from FLASK_ENV env
variable) that is used by flask and extensions to set things like
debug mode.

Switching to it allows us to standardise the approach across our
apps and base the config selection on application.env instead of
the custom environment variable.