### PR TITLE
Prevent documents from being indexed by search engines

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -31,5 +31,6 @@ def download_document(service_id, document_id):
 
     response = make_response(send_file(document['body'], mimetype=document['mimetype']))
     response.headers['Content-Length'] = document['size']
+    response.headers['X-Robots-Tag'] = 'noindex, nofollow'
 
     return response

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -37,6 +37,7 @@ def test_document_download(client, store):
         'Content-Length': '100',
         'Content-Type': 'application/pdf',
         'NotifyRequestID': mock.ANY,
+        'X-Robots-Tag': 'noindex, nofollow'
     }
     store.get.assert_called_once_with(
         UUID('00000000-0000-0000-0000-000000000000'),


### PR DESCRIPTION
Setting the X-Robots-Tag header to `noindex, nofollow` prevents search engines from indexing the page or following any links to other pages.

This is different from robots.txt (which prevents pages from being crawled by search engines) since it also stops any documents linked from other websites from showing up in search results.