### PR TITLE
Allow CSV document uploads

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,8 @@ class Config(metaclass=MetaFlaskEnv):
 
     ALLOWED_MIME_TYPES = [
         'application/pdf',
+        'text/csv',
+        'text/plain',
     ]
 
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -91,13 +91,13 @@ def test_document_upload_unknown_type(client):
         '/services/12345678-1111-1111-1111-123456789012/documents',
         content_type='multipart/form-data',
         data={
-            'document': (io.BytesIO(b'pdf file contents\n'), 'file.pdf')
+            'document': (io.BytesIO(b'\x00pdf file contents\n'), 'file.pdf')
         }
     )
 
     assert response.status_code == 400
     assert response.json == {
-        'error': "Unsupported document type 'text/plain'. Supported types are: ['application/pdf']"
+        'error': "Unsupported document type 'application/octet-stream'. Supported types are: ['application/pdf', 'text/csv', 'text/plain']" # noqa
     }
 
 


### PR DESCRIPTION
We want to allow services to upload CSV files. CSVs are mostly recognised as plain text by libmagic, so we have to allow all text files at once.

Adding text/csv covers any edge cases that might be recognised by libmagic as well as make the error message more clear (specifically mentioning that CSVs are allowed).