### PR TITLE
Add some tolerance to the max document size check

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,7 @@ class Config(metaclass=MetaFlaskEnv):
         'text/plain',
     ]
 
-    MAX_CONTENT_LENGTH = 2 * 1024 * 1024
+    MAX_CONTENT_LENGTH = 2 * 1024 * 1024 + 1024
 
     FRONTEND_HOSTNAME = None
 

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -101,6 +101,25 @@ def test_document_upload_unknown_type(client):
     }
 
 
+def test_document_file_size_just_right(client, store, antivirus):
+    store.put.return_value = {
+        'id': 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+        'encryption_key': bytes(32),
+    }
+
+    antivirus.scan.return_value = True
+
+    response = client.post(
+        '/services/12345678-1111-1111-1111-123456789012/documents',
+        content_type='multipart/form-data',
+        data={
+            'document': (io.BytesIO(b'%PDF-1.5 ' + b'a' * (2 * 1024 * 1024 - 8)), 'file.pdf')
+        }
+    )
+
+    assert response.status_code == 201
+
+
 def test_document_file_size_too_large(client):
     response = client.post(
         '/services/12345678-1111-1111-1111-123456789012/documents',


### PR DESCRIPTION
MAX_CONTENT_LENGTH is checking the value of the request's Content-
Length header. This is generally slightly larger than the actual
uploaded file size since the multipart POST request body will include
data boundaries and Content-Type/Content-Disposition headers for
each file. It doesn't have a set overhead size since it depends on
the client implementation and the uploaded file name.

We don't really care if a file is slightly larger than 2MB, but we
need to allow any files that are below 2MB (since that's what users
would expect based on our documentation) so we add a 1KB buffer to
the content length check, which should cover the size of the
multipart form wrapper.