### PR TITLE
Bump runtime version to 3.6.6

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.4
+python-3.6.6


### PR DESCRIPTION
PaaS will be updating the python-buildpack to 1.6.20. Python 3.6.4 was dropped in the 1.6.19: https://github.com/cloudfoundry/python-buildpack/releases/tag/v1.6.19