### PR TITLE
Fix awscli/botocore version incompatibility

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,8 +8,6 @@ boto3==1.9.64
 
 python-magic==0.4.15
 
-git+https://github.com/alphagov/notifications-utils.git@30.7.1#egg=notifications-utils==30.7.1
-
 # PaaS
 
 gunicorn==19.7.1  # >19.8 stops eventlet workers after a timeout
@@ -18,3 +16,5 @@ eventlet==0.24.1
 awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.2.0
+
+git+https://github.com/alphagov/notifications-utils.git@30.7.2#egg=notifications-utils==30.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,6 @@ boto3==1.9.64
 
 python-magic==0.4.15
 
-git+https://github.com/alphagov/notifications-utils.git@30.7.1#egg=notifications-utils==30.7.1
-
 # PaaS
 
 gunicorn==19.7.1  # >19.8 stops eventlet workers after a timeout
@@ -20,11 +18,13 @@ awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.2.0
 
+git+https://github.com/alphagov/notifications-utils.git@30.7.2#egg=notifications-utils==30.7.2
+
 ## The following requirements were added by pip freeze:
-awscli==1.15.79
+awscli==1.16.84
 bleach==2.1.3
 blinker==1.4
-botocore==1.12.65
+botocore==1.12.74
 certifi==2018.11.29
 chardet==3.0.4
 Click==7.0
@@ -44,7 +44,7 @@ monotonic==1.5
 orderedset==2.0.1
 phonenumbers==8.9.4
 prometheus-client==0.2.0
-pyasn1==0.4.4
+pyasn1==0.4.5
 PyPDF2==1.26.0
 python-dateutil==2.7.5
 python-json-logger==0.1.8


### PR DESCRIPTION
awscli 1.15 requires botocore 1.10, but 1.12 is installed instead.

Since pip installs the first package version that it comes across,
awscli 1.15 is picked up from notification-utils dependencies, but
botocore is taken from boto3.

Moving utils after awscli-cwlogs (matching the order in notifications-api
requirements) makes pip install the latest versions of both awscli and
botocore, which should be compatible with each other.