### PR TITLE
Update notification-utils to the latest version

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,11 +10,11 @@ python-magic==0.4.15
 
 # PaaS
 
-gunicorn==19.7.1  # >19.8 stops eventlet workers after a timeout
+gunicorn==19.7.1  # pyup: ignore # >19.8 stops eventlet workers after a timeout
 eventlet==0.24.1
 
 awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.7.2#egg=notifications-utils==30.7.2
+git+https://github.com/alphagov/notifications-utils.git@30.7.5#egg=notifications-utils==30.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,20 +11,20 @@ python-magic==0.4.15
 
 # PaaS
 
-gunicorn==19.7.1  # >19.8 stops eventlet workers after a timeout
+gunicorn==19.7.1  # pyup: ignore # >19.8 stops eventlet workers after a timeout
 eventlet==0.24.1
 
 awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.2.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.7.2#egg=notifications-utils==30.7.2
+git+https://github.com/alphagov/notifications-utils.git@30.7.5#egg=notifications-utils==30.7.5
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.84
-bleach==2.1.3
+awscli==1.16.96
+bleach==3.0.2
 blinker==1.4
-botocore==1.12.74
+botocore==1.12.86
 certifi==2018.11.29
 chardet==3.0.4
 Click==7.0
@@ -33,30 +33,29 @@ dnspython==1.16.0
 docutils==0.14
 Flask-Redis==0.3.0
 greenlet==0.4.15
-html5lib==1.0.1
-idna==2.7
+idna==2.8
 itsdangerous==1.1.0
 Jinja2==2.10
 jmespath==0.9.3
 MarkupSafe==1.1.0
-mistune==0.8.3
+mistune==0.8.4
 monotonic==1.5
 orderedset==2.0.1
-phonenumbers==8.9.4
+phonenumbers==8.10.2
 prometheus-client==0.2.0
 pyasn1==0.4.5
 PyPDF2==1.26.0
 python-dateutil==2.7.5
-python-json-logger==0.1.8
-pytz==2018.5
+python-json-logger==0.1.10
+pytz==2018.9
 PyYAML==3.12
-redis==3.0.1
-requests==2.20.1
+redis==3.1.0
+requests==2.21.0
 rsa==3.4.2
 s3transfer==0.1.13
 six==1.12.0
 smartypants==2.0.1
-statsd==3.2.2
+statsd==3.3.0
 urllib3==1.24.1
 webencodings==0.5.1
 Werkzeug==0.14.1


### PR DESCRIPTION
Downgrades gunicorn to 19.7.1 to fix eventlet patching and updates
insecure dependencies (requests and bleach).