### PR TITLE
Only pin python runtime to the minor 3.6 version

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.6
+python-3.6


### PR DESCRIPTION
Python patch releases are pretty stable and since PaaS buildpacks deprecate older patch versions quite regularly the recommended approach is to not pin the individual 3.6.x release.