### PR TITLE
deploy with zero downtime deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 
 CF_APP = document-download-api
 
+CF = $(if $(shell which cf-cli-6.43), cf-cli-6.43, cf)
+
 .PHONY: run
 run:
 	FLASK_APP=application.py FLASK_ENV=development flask run -p 7000
@@ -39,19 +41,19 @@ test-requirements:
 preview:
 	$(eval export CF_SPACE=preview)
 	$(eval export DNS_NAME=documents.notify.works)
-	cf target -s ${CF_SPACE}
+	${CF} target -s ${CF_SPACE}
 
 .PHONY: staging
 staging:
 	$(eval export CF_SPACE=staging)
 	$(eval export DNS_NAME=documents.staging-notify.works)
-	cf target -s ${CF_SPACE}
+	${CF} target -s ${CF_SPACE}
 
 .PHONY: production
 production:
 	$(eval export CF_SPACE=production)
 	$(eval export DNS_NAME=documents.service.gov.uk)
-	cf target -s ${CF_SPACE}
+	${CF} target -s ${CF_SPACE}
 
 .PHONY: generate-manifest
 generate-manifest:
@@ -67,37 +69,25 @@ generate-manifest:
 .PHONY: cf-push
 cf-push:
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
-	cf push ${CF_APP} -f <(make -s generate-manifest)
+	${CF} push ${CF_APP} -f <(make -s generate-manifest)
 
 .PHONY: cf-deploy
 cf-deploy: ## Deploys the app to Cloud Foundry
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
-	@cf app --guid ${CF_APP} || exit 1
-	cf rename ${CF_APP} ${CF_APP}-rollback
-	cf push ${CF_APP} -f <(make -s generate-manifest)
-	cf scale -i $$(cf curl /v2/apps/$$(cf app --guid ${CF_APP}-rollback) | jq -r ".entity.instances" 2>/dev/null || echo "1") ${CF_APP}
-	cf stop ${CF_APP}-rollback
-	# sleep for 10 seconds to try and make sure that all worker threads (either web api or celery) have finished before we delete
-	sleep 10
+	@${CF} app --guid ${CF_APP} || exit 1
 
-	# get the new GUID, and find all crash events for that. If there were any crashes we will abort the deploy.
-	[ $$(cf curl "/v2/events?q=type:app.crash&q=actee:$$(cf app --guid ${CF_APP})" | jq ".total_results") -eq 0 ]
-	cf delete -f ${CF_APP}-rollback
+	${CF} v3-apply-manifest ${CF_APP} -f <(make -s generate-manifest)
+	${CF} v3-zdt-push ${CF_APP} --wait-for-deploy-complete
 
 .PHONY: cf-rollback
 cf-rollback: ## Rollbacks the app to the previous release
-	$(if ${CF_APP},,$(error Must specify CF_APP))
-	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
-	@cf app --guid ${CF_APP}-rollback || exit 1
-	@[ $$(cf curl /v2/apps/`cf app --guid ${CF_APP}-rollback` | jq -r ".entity.state") = "STARTED" ] || (echo "Error: rollback is not possible because ${CF_APP}-rollback is not in a started state" && exit 1)
-	cf delete -f ${CF_APP} || true
-	cf rename ${CF_APP}-rollback ${CF_APP}
+	# No action here - if we fail, we can just push a new build over the top.
 
 .PHONY: cf-create-cdn-route
 cf-create-cdn-route:
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	$(if ${DNS_NAME},,$(error Must specify DNS_NAME))
-	cf create-service cdn-route cdn-route documents-cdn-route -c '{"domain": "${DNS_NAME}"}'
+	${CF} create-service cdn-route cdn-route documents-cdn-route -c '{"domain": "${DNS_NAME}"}'
 
 .PHONY: cf-login
 cf-login: ## Log in to Cloud Foundry
@@ -105,7 +95,7 @@ cf-login: ## Log in to Cloud Foundry
 	$(if ${CF_PASSWORD},,$(error Must specify CF_PASSWORD))
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	@echo "Logging in to Cloud Foundry on ${CF_API}"
-	@cf login -a "${CF_API}" -u ${CF_USERNAME} -p "${CF_PASSWORD}" -o "${CF_ORG}" -s "${CF_SPACE}"
+	@${CF} login -a "${CF_API}" -u ${CF_USERNAME} -p "${CF_PASSWORD}" -o "${CF_ORG}" -s "${CF_SPACE}"
 
 .PHONY: docker-build
 docker-build:

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: unset GUNICORN_CMD_ARGS; scripts/run_app_paas.sh gunicorn -c gunicorn_config.py application

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -5,8 +5,8 @@ applications:
   instances: 1
   memory: 512M
 
-  buildpack: python_buildpack
-  command: unset GUNICORN_CMD_ARGS; scripts/run_app_paas.sh gunicorn -c gunicorn_config.py application
+  buildpacks:
+    - python_buildpack
 
   {% set hostname={
     "preview": "documents.notify.works",


### PR DESCRIPTION
# What

Replace our own zero downtime blue-green kludge with new cloudfoundry builtin mechanisms

# Why

We're currently using our own handrolled zero downtime deploy script, it works as follows

1. Rename app to "{APP_NAME}-rollback"
2. Push new code to regular app name
3. Scale new app to have the same number of instances as the old app.
4. Assert there are no crash events on the new app.
5. Stop and delete the old app.

We've seen problems at step 5 - both the new app and the old app are serving traffic/processing tasks at this point, and we've often seen "permission denied for relationship" psycopg2 errors - these are because when you delete an app, cf removes the user from the database. Additionally, I'm not very convinced at how robust our crash recovery rollback process is - it appears to stop the old app before checking for crashes, which will then cause the rollback to fail I think.

# How

Using the new, underdocumented, high tech `v3-zdt` endpoints of course! Some information can be found here:

* https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html
* https://v3-apidocs.cloudfoundry.org/version/3.68.0/index.html#introduction

The process is now:

* Apply manifest using `cf v3-apply-manifest`
* Push code using `cf v3-zdt-deploy`

`v3-apply-manifest` takes new environment variables, etc, and pass them to cloudfoundry to use when the app is next restaged. This won't affect scaling actions. Only restarts, restages, pushes etc.

`v3-zdt-deploy` will first build the droplet (blob that combines manifest and source code, with packages etc installed). Then, one by one, it will add a new instance of the new droplet, when that is running it will remove one instance of the old droplet, and continue this until all instances are running on the new droplet.

if the deployment fails (ie the new apps crash) no old apps will be removed. However, the deployment will still be in the state `DEPLOYING` (you can see it by checking the following curl command):
```sh
cf curl "/v3/deployments" -d '{"relationships": {"app": {"data": {"guid": "${MY_APP_GUID}"}}}}'
```

The deployment can be cancelled using `cf cancel-zdt-push ${APP_NAME}`. However, we've decided not to use cancel (see comment below). We use the `--wait-for-deploy-complete` flag when pushing, which waits about five minutes before returning a non-zero exit code. The deployment will still be going on at this point - cf will keep on trying to (one-by-one) bring up new instances of the new app.

A succesful deployment can be quickly rolled back by doing the following steps:`cf v3-set-droplet ${APP_NAME} -d ${OLD_DROPLET_GUID}` and then `cf v3-zdt-restart`. Or of course you could check out the old code and call `cf v3-zdt-push` again - this is how we'll handle this on jenkins.

The old droplet guid can only be found if you previously checked `cf curl /v3/apps/${APP_GUID}/droplets/current`. There is a `v3-droplets` cf command, but it doesn't distinguish the current droplet from any others, it's hard to say from that list what is working, what is deployed to which spaces, etc.

Notes: the `command` field doesn't work in manifests any more (despite claiming to) so we've had to move it to a Procfile. Also, buildpacks is now a list. 🤷‍♂️