### PR TITLE
Don't specify instance counts in manifests

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -2,7 +2,6 @@
 applications:
 - name: document-download-api
 
-  instances: 1
   memory: 512M
 
   buildpacks:


### PR DESCRIPTION
Otherwise, you can't do a deploy while an existing deploy is in progress if the app has been scaled to a different amount, since the first step of the deploy is to apply the manifest, which will try and scale the app.

We let the autoscaler take care of the instance count for apps that care about it anyway.