### PR TITLE
cancel any existing deploy before pushing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	@${CF} app --guid ${CF_APP} || exit 1
 
+	# cancel any existing deploys to ensure we can apply manifest (if a deploy is in progress you'll see ScaleDisabledDuringDeployment)
+	${CF} v3-cancel-zdt-push || true
+
 	${CF} v3-apply-manifest ${CF_APP} -f <(make -s generate-manifest)
 	${CF} v3-zdt-push ${CF_APP} --wait-for-deploy-complete
 


### PR DESCRIPTION
pushing an app involves two steps: applying the manifest, and pushing the source code.

Applying a manifest will _immediately_ scale the app to have whatever instance count, memory and disk quota the manifest says. It'll also apply environment variable changes to the next droplet (ie: next push).

zdt deploys block scale actions, and as such, if there's a deploy under way, you can't push a new build. Failing deploys carry on after cf-cli returns a non-zero build, so we need to cancel previous deploys before starting another.

There is a risk introduced with this - if, for whatever reason, two builds were run in parallel, specifically, one push happens on top of another push, when you cancel the second one, it'll roll back to the first push's droplet, rather than the stable state from before the first push started.

I think the risk of this happening is low because when we deploy, we lock jenkins so only one thread can execute a deploy to an env at once. If someone is manually pushing from their computer, this is a plausible outcome however.