### PR TITLE
cancel zdt deploy on rollback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 
 .PHONY: cf-rollback
 cf-rollback: ## Rollbacks the app to the previous release
-	# No action here - if we fail, we can just push a new build over the top.
+	cf v3-cancel-zdt-push ${CF_APP}
 
 .PHONY: cf-create-cdn-route
 cf-create-cdn-route:


### PR DESCRIPTION
you can't scale an app while it's deploying. If a build fails, it may take us a while to identify the cause, create a fix and get that deployed, and it would be problematic if we couldn't scale the app for that time.

So, on rollback, cancel the deploy. Still keep the cancel step in the deploy phase, JustInCase™. It shouldn't ever trip now, but if jenkins died unexpectedly and couldn't hit the `make cf-rollback` command we'll still need it.