### PR TITLE
Run two instances instead of one

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -4,6 +4,8 @@ applications:
 
   memory: 512M
 
+  instances: 2
+
   buildpacks:
     - python_buildpack
 


### PR DESCRIPTION
We only run one instance in production. This should be 2 for high
availability