### PR TITLE
Don't let pyup update requirements.txt apart from for security

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -6,3 +6,5 @@ search: False
 requirements:
   - requirements-app.txt
   - requirements-dev.txt
+  - requirements.txt:
+      update: False


### PR DESCRIPTION
As per https://pyup.io/docs/bot/config/#specify-files, this means pyup
will not update requirements.txt under general circumstances. The
exception will be for security updates - although we won't merge the
security update as is, it will hopefully be the prompt for us to run
make freeze-requirements which will likely solve the insecure
requirement.