### PR TITLE
Add endpoint to check if file is in S3

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -34,3 +34,31 @@ def download_document(service_id, document_id):
     response.headers['X-Robots-Tag'] = 'noindex, nofollow'
 
     return response
+
+
+@download_blueprint.route('/services/<uuid:service_id>/documents/<uuid:document_id>/check', methods=['GET'])
+def check_document_exists(service_id, document_id):
+    if 'key' not in request.args:
+        return jsonify(error='Missing decryption key'), 400
+
+    try:
+        key = base64_to_bytes(request.args['key'])
+    except ValueError:
+        return jsonify(error='Invalid decryption key'), 400
+
+    try:
+        document_exists = document_store.check_document_exists(service_id, document_id, key)
+    except DocumentStoreError as e:
+        current_app.logger.warning(
+            'Failed to check if document exists: {}'.format(e),
+            extra={
+                'service_id': service_id,
+                'document_id': document_id,
+            }
+        )
+        return jsonify(error=str(e)), 400
+
+    response = make_response({'file_exists': str(document_exists)})
+    response.headers['X-Robots-Tag'] = 'noindex, nofollow'
+
+    return response

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -60,6 +60,24 @@ class DocumentStore:
             'size': document['ContentLength']
         }
 
+    def check_document_exists(self, service_id, document_id, decryption_key):
+        """
+        decryption_key should be raw bytes
+        """
+
+        try:
+            self.s3.head_object(
+                Bucket=self.bucket,
+                Key=self.get_document_key(service_id, document_id),
+                SSECustomerKey=decryption_key,
+                SSECustomerAlgorithm='AES256'
+            )
+            return True
+        except BotoClientError as e:
+            if e.response['Error']['Code'] == '404':
+                return False
+            raise DocumentStoreError(e.response['Error'])
+
     def generate_encryption_key(self):
         return os.urandom(32)
 


### PR DESCRIPTION
We want a way of knowing if a file is in S3 so that document-dowload-frontend can display a different page to users instead of showing them a link to the document. This adds a method to the `DocumentStore` class to check and a new endpoint to display the result.

[Pivotal story](https://www.pivotaltracker.com/story/show/172199088)