### PR TITLE
Remove FileStorage

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -24,7 +24,7 @@ def upload_document(service_id):
         raw_content = b64decode(request.json['document'])
         if len(raw_content) > current_app.config['MAX_CONTENT_LENGTH']:
             abort(413)
-        file_data = FileStorage(BytesIO(raw_content))
+        file_data = BytesIO(raw_content)
         is_csv = request.json.get('is_csv', False)
     else:
         if 'document' not in request.files:

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -2,7 +2,6 @@ from io import BytesIO
 from base64 import b64decode
 
 from flask import abort, Blueprint, current_app, jsonify, request
-from werkzeug.datastructures import FileStorage
 
 from app import document_store, antivirus_client
 from app.utils import get_mime_type


### PR DESCRIPTION
Please see: https://github.com/alphagov/notifications-api/pull/2836#issuecomment-627460349

I tried to investigate this but cannot quite figure out why this is not working as it should. 

Given that `FileStorage` is a [thin wrapper](https://github.com/pallets/werkzeug/blob/master/src/werkzeug/datastructures.py#L2964) around the underlying stream here, this should be (1) safe and (2) it works.