### PR TITLE
Set CSV download Content-Disposition

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -29,7 +29,23 @@ def download_document(service_id, document_id):
         )
         return jsonify(error=str(e)), 400
 
-    response = make_response(send_file(document['body'], mimetype=document['mimetype']))
+    send_file_kwargs = {
+        'mimetype': document['mimetype'],
+    }
+    if document['mimetype'] == 'text/csv':
+        send_file_kwargs.update(
+            {
+                'attachment_filename': f'{document_id}.csv',
+                'as_attachment': True,
+            }
+        )
+
+    response = make_response(
+        send_file(
+            document['body'],
+            **send_file_kwargs,
+        )
+    )
     response.headers['Content-Length'] = document['size']
     response.headers['X-Robots-Tag'] = 'noindex, nofollow'
 

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -33,6 +33,9 @@ def download_document(service_id, document_id):
         'mimetype': document['mimetype'],
     }
     if document['mimetype'] == 'text/csv':
+        # Force browsers to download CSV files with a specified filename; this
+        # is because many browsers do not add a .csv file extension to downloaded
+        # files - so we need to be more explicit.
         send_file_kwargs.update(
             {
                 'attachment_filename': f'{document_id}.csv',

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -48,6 +48,10 @@ def test_document_download(client, store):
 
 
 def test_csv_document_download(client, store):
+    """
+    Test that CSV file responses have the expected Content-Type/Content-Disposition
+    required for browsers to download files in a way that is useful for users.
+    """
     store.get.return_value = {
         'body': io.BytesIO(b'a,b,c'),
         'mimetype': 'text/csv',

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -47,6 +47,42 @@ def test_document_download(client, store):
     )
 
 
+def test_csv_document_download(client, store):
+    store.get.return_value = {
+        'body': io.BytesIO(b'a,b,c'),
+        'mimetype': 'text/csv',
+        'size': 100
+    }
+
+    document_id = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+    response = client.get(
+        url_for(
+            'download.download_document',
+            service_id='00000000-0000-0000-0000-000000000000',
+            document_id=document_id,
+            key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',  # 32 \x00 bytes
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.get_data() == b'a,b,c'
+    assert dict(response.headers) == {
+        'Cache-Control': mock.ANY,
+        'Expires': mock.ANY,
+        'Content-Length': '100',
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': f'attachment; filename={document_id}.csv',
+        'X-B3-SpanId': 'None',
+        'X-B3-TraceId': 'None',
+        'X-Robots-Tag': 'noindex, nofollow'
+    }
+    store.get.assert_called_once_with(
+        UUID('00000000-0000-0000-0000-000000000000'),
+        UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
+        bytes(32)
+    )
+
+
 def test_document_download_without_decryption_key(client, store):
     response = client.get(
         url_for(


### PR DESCRIPTION
This PR ensures that download responses for CSV files have an explicit `Content-Disposition: attachment; filename=<uuid>.csv` header set.

This is necessary as browser handling for responses for CSV responses from the download API endpoint was a little spotty.  The experience for the user would vary across OS/browser combinations, e.g. opening spreadsheet applications, downloading a file as <uuid>.txt, downloading a file with no extension or just showing the raw text in the browser.  

By making this an explicit download, we can ensure that users always download a `<uuid>.csv` file.

I have tested this on Linux (Chrome and Firefox) and Windows (Chrome, IE11, Edge) - downloads occur as expected.