### PR TITLE
Force download of rtf files rather than inline

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -33,12 +33,20 @@ def download_document(service_id, document_id):
         'mimetype': document['mimetype'],
     }
     if document['mimetype'] == 'text/csv':
-        # Force browsers to download CSV files with a specified filename; this
-        # is because many browsers do not add a .csv file extension to downloaded
-        # files - so we need to be more explicit.
+        # Give CSV files the 'Content-Disposition' header to ensure they are downloaded
+        # rather than shown as raw text in the users browser
         send_file_kwargs.update(
             {
                 'attachment_filename': f'{document_id}.csv',
+                'as_attachment': True,
+            }
+        )
+    elif document['mimetype'] in current_app.config['ALLOWED_FILE_TYPES']['rtf']:
+        # Give RTF files the 'Content-Disposition' header to ensure they are downloaded
+        # rather than shown as raw text in the users browser
+        send_file_kwargs.update(
+            {
+                'attachment_filename': f'{document_id}.rtf',
                 'as_attachment': True,
             }
         )

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -87,6 +87,52 @@ def test_csv_document_download(client, store):
     )
 
 
+@pytest.mark.parametrize(
+    "rtf_mimetype, expected_content_type_header", [
+        ('text/rtf', 'text/rtf; charset=utf-8'),
+        ('application/rtf', 'application/rtf'),
+    ]
+)
+def test_rtf_document_download(client, store, rtf_mimetype, expected_content_type_header):
+    """
+    Test that RTF file responses have the expected Content-Type/Content-Disposition
+    required for browsers to download files in a way that is useful for users.
+    """
+    store.get.return_value = {
+        'body': io.BytesIO(b'a,b,c'),
+        'mimetype': rtf_mimetype,
+        'size': 100
+    }
+
+    document_id = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+    response = client.get(
+        url_for(
+            'download.download_document',
+            service_id='00000000-0000-0000-0000-000000000000',
+            document_id=document_id,
+            key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',  # 32 \x00 bytes
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.get_data() == b'a,b,c'
+    assert dict(response.headers) == {
+        'Cache-Control': mock.ANY,
+        'Expires': mock.ANY,
+        'Content-Length': '100',
+        'Content-Type': expected_content_type_header,
+        'Content-Disposition': f'attachment; filename={document_id}.rtf',
+        'X-B3-SpanId': 'None',
+        'X-B3-TraceId': 'None',
+        'X-Robots-Tag': 'noindex, nofollow'
+    }
+    store.get.assert_called_once_with(
+        UUID('00000000-0000-0000-0000-000000000000'),
+        UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
+        bytes(32)
+    )
+
+
 def test_document_download_without_decryption_key(client, store):
     response = client.get(
         url_for(


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1443052

We have complaints from users that when they click the link to download
an rtf file it is shown as raw text in their browser as there is no
'Content-Disposition' header. This commit does similar to how we treat
CSVs and adds the header such that they will download for a user.

Note when testing. This problem does not appear to exist on my mac
(regardless of if I use Safari, Chrome or Edge) so it likely a
combination of browser and OS system so I have not been able to
replicate myself but have taken the same approach as we did for CSVs and
tested that it does at least not break things.