### PR TITLE
Fix not using 'bash' to run Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 CF_API ?= api.cloud.service.gov.uk
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 


### PR DESCRIPTION
This was removed accidentally in [1] and is a reserved variable in
Makefiles to set the running shell [2].

[1]: https://github.com/alphagov/document-download-api/pull/159
[2]: https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)