### PR TITLE
Allow uploading simple Excel spreadsheets

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,6 +18,7 @@ class Config(metaclass=MetaFlaskEnv):
         'docx': ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
         'odt': ['application/vnd.oasis.opendocument.text'],
         'rtf': ['application/rtf', 'text/rtf'],
+        'xlsx': ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
     }
 
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024 + 1024

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -137,7 +137,7 @@ def test_document_upload_unknown_type(client, content_type):
     assert response.status_code == 400
     assert response.json['error'] == (
         "Unsupported file type 'application/octet-stream'. "
-        "Supported types are: '.csv', '.doc', '.docx', '.odt', '.pdf', '.rtf', '.txt'"
+        "Supported types are: '.csv', '.doc', '.docx', '.odt', '.pdf', '.rtf', '.txt', '.xlsx'"
     )
 
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177188288

This has been requested by our users. While there are many Excel
formats we could support - macro-enabled, templated, binary - we
want to limit the set to those with an established a user need.

I've tested this manually with a sample .xlsx file provided by the
user, and can confirm it uploads/downloads as expected.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)