### PR TITLE
Revert "Allow uploading simple Excel spreadsheets"

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,7 +18,6 @@ class Config(metaclass=MetaFlaskEnv):
         'docx': ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
         'odt': ['application/vnd.oasis.opendocument.text'],
         'rtf': ['application/rtf', 'text/rtf'],
-        'xlsx': ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
     }
 
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024 + 1024

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -137,7 +137,7 @@ def test_document_upload_unknown_type(client, content_type):
     assert response.status_code == 400
     assert response.json['error'] == (
         "Unsupported file type 'application/octet-stream'. "
-        "Supported types are: '.csv', '.doc', '.docx', '.odt', '.pdf', '.rtf', '.txt', '.xlsx'"
+        "Supported types are: '.csv', '.doc', '.docx', '.odt', '.pdf', '.rtf', '.txt'"
     )
 
 

--- a/tests/utils/test_mime_types.py
+++ b/tests/utils/test_mime_types.py
@@ -13,8 +13,8 @@ from app.utils import get_mime_type
     ('test.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
     ('test.odt', 'application/vnd.oasis.opendocument.text'),
     ('test.rtf', 'text/rtf'),
-    ('test.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
     # not supported by doc dl
+    ('test.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
     ('test.pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'),
     ('test.zip', 'application/zip'),
     ('corrupted.zip', 'application/octet-stream'),


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177188288

This reverts commit a1b425e4187d0ee9a9787bf18c325b9810b5020d. After
testing with different browsers we discovered an issue where the file
extension is missing for .xlsx and .docx attachments downloaded via
MS Edge, which prevents them being opened [1]. Since .xlsx is a recent
addition, we decided to remove support for it until we fix the issue.

I've left the test for the MIME type in as it's still valid for us to
check we can infer it correctly, whether it's allowed or not.

[1]: https://github.com/alphagov/document-download-api/pull/162#issuecomment-803006654




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)