### PR TITLE
Fix downloaded files not having an extension

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,15 +9,16 @@ class Config(metaclass=MetaFlaskEnv):
 
     DOCUMENTS_BUCKET = None
 
-    # map of file extension to MIME TYPE.
+    # map of MIME types to preferred extension
     ALLOWED_FILE_TYPES = {
-        'pdf': ['application/pdf'],
-        'csv': ['text/csv'],
-        'txt': ['text/plain'],
-        'doc': ['application/msword'],
-        'docx': ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
-        'odt': ['application/vnd.oasis.opendocument.text'],
-        'rtf': ['application/rtf', 'text/rtf'],
+        'application/pdf': 'pdf',
+        'text/csv': 'csv',
+        'text/plain': 'txt',
+        'application/msword': 'doc',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+        'application/vnd.oasis.opendocument.text': 'odt',
+        'application/rtf': 'rtf',
+        'text/rtf': 'rtf',
     }
 
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024 + 1024

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -44,11 +44,9 @@ def download_document(service_id, document_id):
         'attachment_filename': f'{document_id}.{extension}',
         'as_attachment': True,
     }
-    if document['mimetype'] == 'application/pdf':
-        # Open PDFs in the browser
-        send_file_kwargs.update({'as_attachment': False})
-    elif document['mimetype'] == 'text/plain':
-        # Open raw text files in the browser
+
+    if extension in ('pdf', 'txt'):
+        # in-browser preview is widely supported, so don't force a download
         send_file_kwargs.update({'as_attachment': False})
 
     response = make_response(

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -36,14 +36,11 @@ def download_document(service_id, document_id):
         )
         return jsonify(error=str(e)), 400
 
-    extension = None
-    for ext, mimetypes in current_app.config['ALLOWED_FILE_TYPES'].items():
-        if document['mimetype'] in mimetypes:
-            extension = ext
-            break
+    mimetype = document['mimetype']
+    extension = current_app.config['ALLOWED_FILE_TYPES'][mimetype]
 
     send_file_kwargs = {
-        'mimetype': document['mimetype'],
+        'mimetype': mimetype,
         'attachment_filename': f'{document_id}.{extension}',
         'as_attachment': True,
     }

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -36,27 +36,23 @@ def download_document(service_id, document_id):
         )
         return jsonify(error=str(e)), 400
 
+    extension = None
+    for ext, mimetypes in current_app.config['ALLOWED_FILE_TYPES'].items():
+        if document['mimetype'] in mimetypes:
+            extension = ext
+            break
+
     send_file_kwargs = {
         'mimetype': document['mimetype'],
+        'attachment_filename': f'{document_id}.{extension}',
+        'as_attachment': True,
     }
-    if document['mimetype'] == 'text/csv':
-        # Give CSV files the 'Content-Disposition' header to ensure they are downloaded
-        # rather than shown as raw text in the users browser
-        send_file_kwargs.update(
-            {
-                'attachment_filename': f'{document_id}.csv',
-                'as_attachment': True,
-            }
-        )
-    elif document['mimetype'] in current_app.config['ALLOWED_FILE_TYPES']['rtf']:
-        # Give RTF files the 'Content-Disposition' header to ensure they are downloaded
-        # rather than shown as raw text in the users browser
-        send_file_kwargs.update(
-            {
-                'attachment_filename': f'{document_id}.rtf',
-                'as_attachment': True,
-            }
-        )
+    if document['mimetype'] == 'application/pdf':
+        # Open PDFs in the browser
+        send_file_kwargs.update({'as_attachment': False})
+    elif document['mimetype'] == 'text/plain':
+        # Open raw text files in the browser
+        send_file_kwargs.update({'as_attachment': False})
 
     response = make_response(
         send_file(

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -1,6 +1,5 @@
 from base64 import b64decode
 from io import BytesIO
-from itertools import chain
 
 from flask import Blueprint, abort, current_app, jsonify, request
 
@@ -36,8 +35,8 @@ def upload_document(service_id):
         return jsonify(error='Value for is_csv must be a boolean'), 400
 
     mimetype = get_mime_type(file_data)
-    if mimetype not in chain(*current_app.config['ALLOWED_FILE_TYPES'].values()):
-        allowed_file_types = ', '.join(sorted(f"'.{x}'" for x in current_app.config['ALLOWED_FILE_TYPES'].keys()))
+    if mimetype not in current_app.config['ALLOWED_FILE_TYPES'].keys():
+        allowed_file_types = ', '.join(sorted({f"'.{x}'" for x in current_app.config['ALLOWED_FILE_TYPES'].values()}))
         return jsonify(error=f"Unsupported file type '{mimetype}'. Supported types are: {allowed_file_types}"), 400
 
     # Our mimetype auto-detection resolves CSV content as text/plain, so we use

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -133,6 +133,47 @@ def test_rtf_document_download(client, store, rtf_mimetype, expected_content_typ
     )
 
 
+def test_docx_document_download(client, store):
+    """
+    Test that DOCX file responses have the expected Content-Type/Content-Disposition
+    required for browsers to download files in a way that is useful for users.
+    """
+    mimetype = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    store.get.return_value = {
+        'body': io.BytesIO(b'a,b,c'),
+        'mimetype': mimetype,
+        'size': 100
+    }
+
+    document_id = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+    response = client.get(
+        url_for(
+            'download.download_document',
+            service_id='00000000-0000-0000-0000-000000000000',
+            document_id=document_id,
+            key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',  # 32 \x00 bytes
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.get_data() == b'a,b,c'
+    assert dict(response.headers) == {
+        'Cache-Control': mock.ANY,
+        'Expires': mock.ANY,
+        'Content-Length': '100',
+        'Content-Type': f'{mimetype}',
+        'Content-Disposition': f'attachment; filename={document_id}.docx',
+        'X-B3-SpanId': 'None',
+        'X-B3-TraceId': 'None',
+        'X-Robots-Tag': 'noindex, nofollow'
+    }
+    store.get.assert_called_once_with(
+        UUID('00000000-0000-0000-0000-000000000000'),
+        UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
+        bytes(32)
+    )
+
+
 def test_document_download_without_decryption_key(client, store):
     response = client.get(
         url_for(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177188288

This forces direct download for the majority of attachments,
which is a necessary part of controlling the filename. Fixing
this is a prerequisite to allowing Excel file types [1]. See the
commit messages for more details.

Previous behaviour (across Chrome, Firefox, MS Edge and IE11):

- `docx` downloads with extension on Chrome, without on all others
- `csv` (with `is_csv`) downloads with extension on all
- `doc` downloads with extension on Chrome, without on all others
- `rtf` downloads with extension on all
- `txt` opens in-browser. Saves without extension for Firefox and Chrome, with extension for IE11.
- `odt` downloads with extension on Chrome, without on all others
- `pdf` opens in-browser. Saves with extension on all.

New behaviour:

- `docx` downloads with extension on all
- `csv` (with `is_csv`) downloads with extension on all
- `doc` downloads with extension on all
- `rtf` downloads with extension on all
- `txt` opens in-browser. Saves without extension for Firefox and Chrome, with extension for IE11.
- `odt` downloads with extension on all
- `pdf` opens in-browser. Saves with extension on all.

[1]: https://github.com/alphagov/document-download-api/pull/164




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)