### PR TITLE
Allow optional extension when downloading files

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,13 +11,14 @@ class Config(metaclass=MetaFlaskEnv):
 
     # map of file extension to MIME TYPE.
     ALLOWED_FILE_TYPES = {
-        'pdf': ['application/pdf'],
-        'csv': ['text/csv'],
-        'txt': ['text/plain'],
-        'doc': ['application/msword'],
-        'docx': ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
-        'odt': ['application/vnd.oasis.opendocument.text'],
-        'rtf': ['application/rtf', 'text/rtf'],
+        'application/pdf': 'pdf',
+        'text/csv': 'csv',
+        'text/plain': 'txt',
+        'application/msword': 'doc',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+        'application/vnd.oasis.opendocument.text': 'odt',
+        'application/rtf': 'rtf',
+        'text/rtf': 'rtf',
     }
 
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024 + 1024

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -14,6 +14,8 @@ from app.utils.urls import get_direct_file_url
 
 download_blueprint = Blueprint('download', __name__, url_prefix='')
 
+FILE_TYPES_TO_FORCE_DOWNLOAD_FOR = ['csv', 'rtf']
+
 
 # Some browsers - Firefox, IE11 - use the final part of the URL as the filename when downloading a file. While we
 # don't use the extension, having it in the URL ensures the downloaded file can be opened correctly on Windows.
@@ -42,22 +44,14 @@ def download_document(service_id, document_id, extension=None):
 
     mimetype = document['mimetype']
     send_file_kwargs = {'mimetype': mimetype}
+    extension = current_app.config['ALLOWED_FILE_TYPES'][mimetype]
 
-    if mimetype == 'text/csv':
+    if extension in FILE_TYPES_TO_FORCE_DOWNLOAD_FOR:
         # Give CSV files the 'Content-Disposition' header to ensure they are downloaded
         # rather than shown as raw text in the users browser
         send_file_kwargs.update(
             {
-                'attachment_filename': f'{document_id}.csv',
-                'as_attachment': True,
-            }
-        )
-    elif current_app.config['ALLOWED_FILE_TYPES'][mimetype] == 'rtf':
-        # Give RTF files the 'Content-Disposition' header to ensure they are downloaded
-        # rather than shown as raw text in the users browser
-        send_file_kwargs.update(
-            {
-                'attachment_filename': f'{document_id}.rtf',
+                'attachment_filename': f'{document_id}.{extension}',
                 'as_attachment': True,
             }
         )

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -84,7 +84,7 @@ def check_document_exists(service_id, document_id):
         return jsonify(error='Invalid decryption key'), 400
 
     try:
-        document_exists = document_store.check_document_exists(service_id, document_id, key)
+        metadata = document_store.get_document_metadata(service_id, document_id, key)
     except DocumentStoreError as e:
         current_app.logger.warning(
             'Failed to check if document exists: {}'.format(e),
@@ -95,7 +95,9 @@ def check_document_exists(service_id, document_id):
         )
         return jsonify(error=str(e)), 400
 
-    response = make_response({'file_exists': str(document_exists)})
-    response.headers['X-Robots-Tag'] = 'noindex, nofollow'
+    response = make_response({
+        'file_exists': str(bool(metadata)),
+    })
 
+    response.headers['X-Robots-Tag'] = 'noindex, nofollow'
     return response

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -39,10 +39,10 @@ def download_document(service_id, document_id, extension=None):
         )
         return jsonify(error=str(e)), 400
 
-    send_file_kwargs = {
-        'mimetype': document['mimetype'],
-    }
-    if document['mimetype'] == 'text/csv':
+    mimetype = document['mimetype']
+    send_file_kwargs = {'mimetype': mimetype}
+
+    if mimetype == 'text/csv':
         # Give CSV files the 'Content-Disposition' header to ensure they are downloaded
         # rather than shown as raw text in the users browser
         send_file_kwargs.update(
@@ -51,7 +51,7 @@ def download_document(service_id, document_id, extension=None):
                 'as_attachment': True,
             }
         )
-    elif document['mimetype'] in current_app.config['ALLOWED_FILE_TYPES']['rtf']:
+    elif current_app.config['ALLOWED_FILE_TYPES'][mimetype] == 'rtf':
         # Give RTF files the 'Content-Disposition' header to ensure they are downloaded
         # rather than shown as raw text in the users browser
         send_file_kwargs.update(

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -14,8 +14,11 @@ from app.utils.store import DocumentStoreError
 download_blueprint = Blueprint('download', __name__, url_prefix='')
 
 
+# Some browsers - Firefox, IE11 - use the final part of the URL as the filename when downloading a file. While we
+# don't use the extension, having it in the URL ensures the downloaded file can be opened correctly on Windows.
+@download_blueprint.route('/services/<uuid:service_id>/documents/<uuid:document_id>.<extension>', methods=['GET'])
 @download_blueprint.route('/services/<uuid:service_id>/documents/<uuid:document_id>', methods=['GET'])
-def download_document(service_id, document_id):
+def download_document(service_id, document_id, extension=None):
     if 'key' not in request.args:
         return jsonify(error='Missing decryption key'), 400
 

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -64,6 +64,7 @@ def upload_document(service_id):
                 service_id=service_id,
                 document_id=document['id'],
                 key=document['encryption_key'],
+                mimetype=mimetype,
             ),
             'url': get_frontend_download_url(
                 service_id=service_id,

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -1,6 +1,5 @@
 from base64 import b64decode
 from io import BytesIO
-from itertools import chain
 
 from flask import Blueprint, abort, current_app, jsonify, request
 
@@ -36,8 +35,8 @@ def upload_document(service_id):
         return jsonify(error='Value for is_csv must be a boolean'), 400
 
     mimetype = get_mime_type(file_data)
-    if mimetype not in chain(*current_app.config['ALLOWED_FILE_TYPES'].values()):
-        allowed_file_types = ', '.join(sorted(f"'.{x}'" for x in current_app.config['ALLOWED_FILE_TYPES'].keys()))
+    if mimetype not in current_app.config['ALLOWED_FILE_TYPES']:
+        allowed_file_types = ', '.join(sorted({f"'.{x}'" for x in current_app.config['ALLOWED_FILE_TYPES'].values()}))
         return jsonify(error=f"Unsupported file type '{mimetype}'. Supported types are: {allowed_file_types}"), 400
 
     # Our mimetype auto-detection resolves CSV content as text/plain, so we use

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -60,22 +60,25 @@ class DocumentStore:
             'size': document['ContentLength']
         }
 
-    def check_document_exists(self, service_id, document_id, decryption_key):
+    def get_document_metadata(self, service_id, document_id, decryption_key):
         """
         decryption_key should be raw bytes
         """
 
         try:
-            self.s3.head_object(
+            metadata = self.s3.head_object(
                 Bucket=self.bucket,
                 Key=self.get_document_key(service_id, document_id),
                 SSECustomerKey=decryption_key,
                 SSECustomerAlgorithm='AES256'
             )
-            return True
+
+            return {
+                'mimetype': metadata['ContentType']
+            }
         except BotoClientError as e:
             if e.response['Error']['Code'] == '404':
-                return False
+                return None
             raise DocumentStoreError(e.response['Error'])
 
     def generate_encryption_key(self):

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -5,19 +5,12 @@ from notifications_utils.base64_uuid import bytes_to_base64, uuid_to_base64
 
 
 def get_direct_file_url(service_id, document_id, key, mimetype):
-    extension = None
-
-    for ext, mimetypes in current_app.config['ALLOWED_FILE_TYPES'].items():
-        if mimetype in mimetypes:
-            extension = ext
-            break
-
     return url_for(
         'download.download_document',
         service_id=service_id,
         document_id=document_id,
         key=bytes_to_base64(key),
-        extension=extension,
+        extension=current_app.config['ALLOWED_FILE_TYPES'][mimetype],
         _external=True
     )
 

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -4,12 +4,20 @@ from flask import current_app, url_for
 from notifications_utils.base64_uuid import bytes_to_base64, uuid_to_base64
 
 
-def get_direct_file_url(service_id, document_id, key):
+def get_direct_file_url(service_id, document_id, key, mimetype):
+    extension = None
+
+    for ext, mimetypes in current_app.config['ALLOWED_FILE_TYPES'].items():
+        if mimetype in mimetypes:
+            extension = ext
+            break
+
     return url_for(
         'download.download_document',
         service_id=service_id,
         document_id=document_id,
         key=bytes_to_base64(key),
+        extension=extension,
         _external=True
     )
 

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -233,7 +233,7 @@ def test_check_document_exists_with_invalid_decryption_key(client):
 
 
 def test_check_document_exists_document_store_error(client, store):
-    store.check_document_exists.side_effect = DocumentStoreError('something went wrong')
+    store.get_document_metadata.side_effect = DocumentStoreError('something went wrong')
     response = client.get(
         url_for(
             'download.check_document_exists',
@@ -248,7 +248,7 @@ def test_check_document_exists_document_store_error(client, store):
 
 
 def test_check_document_exists_when_document_is_in_s3(client, store):
-    store.check_document_exists.return_value = True
+    store.get_document_metadata.return_value = {'mimetype': 'text/plain'}
     response = client.get(
         url_for(
             'download.check_document_exists',
@@ -264,7 +264,7 @@ def test_check_document_exists_when_document_is_in_s3(client, store):
 
 
 def test_check_document_exists_when_document_is_not_in_s3(client, store):
-    store.check_document_exists.return_value = False
+    store.get_document_metadata.return_value = None
     response = client.get(
         url_for(
             'download.check_document_exists',

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -234,72 +234,63 @@ def test_unauthorized_document_upload_json(client):
 
 
 @pytest.mark.parametrize(
-    'file_name,extra_form_data,expected_mimetype,expected_extension',
+    'file_name,extra_form_data,expected_mimetype',
     (
         (
             'test.csv',
             {'is_csv': True},
             'text/csv',
-            'csv',
         ),
         (
             'test.csv',
             {'is_csv': False},
             'text/plain',
-            'txt',
         ),
         (
             'test.csv',
             {},
             'text/plain',
-            'txt',
         ),
         (
             'test.txt',
             {'is_csv': True},
             'text/csv',
-            'csv',
         ),
         (
             'test.txt',
             {'is_csv': False},
             'text/plain',
-            'txt',
         ),
         (
             'test.txt',
             {},
             'text/plain',
-            'txt',
         ),
         (
             'test.pdf',
             {'is_csv': True},
             'application/pdf',
-            'pdf',
         ),
         (
             'test.pdf',
             {'is_csv': False},
             'application/pdf',
-            'pdf',
         ),
         (
             'test.pdf',
             {},
             'application/pdf',
-            'pdf',
         ),
     )
 )
 def test_document_upload_csv_handling(
+    app,
     client,
     store,
     antivirus,
     file_name,
     extra_form_data,
     expected_mimetype,
-    expected_extension
 ):
 
     store.put.return_value = {
@@ -333,7 +324,7 @@ def test_document_upload_csv_handling(
                 'http://document-download.test',
                 '/services/00000000-0000-0000-0000-000000000000',
                 '/documents/ffffffff-ffff-ffff-ffff-ffffffffffff',
-                f'.{expected_extension}',
+                f'.{app.config["ALLOWED_FILE_TYPES"][expected_mimetype]}',
                 '?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
             ]),
         },

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -73,7 +73,7 @@ def test_document_upload_returns_link_to_frontend(client, store, antivirus, cont
             'direct_file_url': ''.join([
                 'http://document-download.test',
                 '/services/00000000-0000-0000-0000-000000000000',
-                '/documents/ffffffff-ffff-ffff-ffff-ffffffffffff',
+                '/documents/ffffffff-ffff-ffff-ffff-ffffffffffff.pdf',
                 '?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
             ]),
             'mimetype': 'application/pdf',
@@ -234,52 +234,61 @@ def test_unauthorized_document_upload_json(client):
 
 
 @pytest.mark.parametrize(
-    'file_name,extra_form_data,expected_mimetype',
+    'file_name,extra_form_data,expected_mimetype,expected_extension',
     (
         (
             'test.csv',
             {'is_csv': True},
             'text/csv',
+            'csv',
         ),
         (
             'test.csv',
             {'is_csv': False},
             'text/plain',
+            'txt',
         ),
         (
             'test.csv',
             {},
             'text/plain',
+            'txt',
         ),
         (
             'test.txt',
             {'is_csv': True},
             'text/csv',
+            'csv',
         ),
         (
             'test.txt',
             {'is_csv': False},
             'text/plain',
+            'txt',
         ),
         (
             'test.txt',
             {},
             'text/plain',
+            'txt',
         ),
         (
             'test.pdf',
             {'is_csv': True},
             'application/pdf',
+            'pdf',
         ),
         (
             'test.pdf',
             {'is_csv': False},
             'application/pdf',
+            'pdf',
         ),
         (
             'test.pdf',
             {},
             'application/pdf',
+            'pdf',
         ),
     )
 )
@@ -289,7 +298,8 @@ def test_document_upload_csv_handling(
     antivirus,
     file_name,
     extra_form_data,
-    expected_mimetype
+    expected_mimetype,
+    expected_extension
 ):
 
     store.put.return_value = {
@@ -323,6 +333,7 @@ def test_document_upload_csv_handling(
                 'http://document-download.test',
                 '/services/00000000-0000-0000-0000-000000000000',
                 '/documents/ffffffff-ffff-ffff-ffff-ffffffffffff',
+                f'.{expected_extension}',
                 '?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
             ]),
         },

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -89,11 +89,12 @@ def test_get_document_with_boto_error(store):
         store.get('service-id', 'document-id', '0f0f0f')
 
 
-def test_check_document_exists_when_document_is_in_s3(store):
-    assert store.check_document_exists('service-id', 'document-id', '0f0f0f') is True
+def test_get_document_metadata_when_document_is_in_s3(store):
+    metadata = store.get_document_metadata('service-id', 'document-id', '0f0f0f')
+    assert metadata == {'mimetype': 'text/plain'}
 
 
-def test_check_document_exists_when_document_is_not_in_s3(store):
+def test_get_document_metadata_when_document_is_not_in_s3(store):
     store.s3.head_object = mock.Mock(side_effect=BotoClientError({
         'Error': {
             'Code': '404',
@@ -101,10 +102,10 @@ def test_check_document_exists_when_document_is_not_in_s3(store):
         }
     }, 'HeadObject'))
 
-    assert store.check_document_exists('service-id', 'document-id', '0f0f0f') is False
+    assert store.get_document_metadata('service-id', 'document-id', '0f0f0f') is None
 
 
-def test_check_document_exists_with_unexpected_boto_error(store):
+def test_get_document_metadata_with_unexpected_boto_error(store):
     store.s3.head_object = mock.Mock(side_effect=BotoClientError({
         'Error': {
             'Code': 'code',
@@ -113,4 +114,4 @@ def test_check_document_exists_with_unexpected_boto_error(store):
     }, 'HeadObject'))
 
     with pytest.raises(DocumentStoreError):
-        store.check_document_exists('service-id', 'document-id', '0f0f0f')
+        store.get_document_metadata('service-id', 'document-id', '0f0f0f')

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -19,9 +19,13 @@ def test_get_frontend_download_url_returns_frontend_url(app):
 
 def test_get_direct_file_url_gets_local_url_without_compressing_uuids(app):
     assert get_direct_file_url(
-        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY
-    ) == 'http://document-download.test/services/{}/documents/{}?key={}'.format(
+        service_id=UUID(int=0),
+        document_id=UUID(int=1),
+        key=SAMPLE_KEY,
+        mimetype='text/plain',
+    ) == 'http://document-download.test/services/{}/documents/{}.{}?key={}'.format(
         '00000000-0000-0000-0000-000000000000',
         '00000000-0000-0000-0000-000000000001',
-        SAMPLE_B64
+        'txt',
+        SAMPLE_B64,
     )


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177188288

This prepares to fixe an issue with not being able to open some attachments
when downloaded with certain browsers on Windows. We'll need a PR in the 
frontend app in order to make use of it.

Please see the commit messages for more details.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)