### PR TITLE
Remove redundant 'file_exists' response flag

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -102,10 +102,6 @@ def get_document_metadata(service_id, document_id):
     else:
         document = None
 
-    response = make_response({
-        'file_exists': str(bool(metadata)),
-        'document': document,
-    })
-
+    response = make_response({'document': document})
     response.headers['X-Robots-Tag'] = 'noindex, nofollow'
     return response

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -226,7 +226,6 @@ def test_get_document_metadata_when_document_is_in_s3(client, store):
     assert response.status_code == 200
     assert response.headers['X-Robots-Tag'] == 'noindex, nofollow'
     assert response.json == {
-        'file_exists': 'True',
         'document': {
             'direct_file_url': ''.join([
                 'http://document-download.test',
@@ -250,5 +249,5 @@ def test_get_document_metadata_when_document_is_not_in_s3(client, store):
     )
 
     assert response.status_code == 200
-    assert response.json == {'file_exists': 'False', 'document': None}
+    assert response.json == {'document': None}
     assert response.headers['X-Robots-Tag'] == 'noindex, nofollow'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177188288

Depends on: https://github.com/alphagov/document-download-frontend/pull/86

This is superseded by the new 'document' value in the response.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)