### PR TITLE
Remove extra route for downloading an attachment

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -20,8 +20,7 @@ FILE_TYPES_TO_FORCE_DOWNLOAD_FOR = ['csv', 'rtf']
 # Some browsers - Firefox, IE11 - use the final part of the URL as the filename when downloading a file. While we
 # don't use the extension, having it in the URL ensures the downloaded file can be opened correctly on Windows.
 @download_blueprint.route('/services/<uuid:service_id>/documents/<uuid:document_id>.<extension>', methods=['GET'])
-@download_blueprint.route('/services/<uuid:service_id>/documents/<uuid:document_id>', methods=['GET'])
-def download_document(service_id, document_id, extension=None):
+def download_document(service_id, document_id, extension):
     if 'key' not in request.args:
         return jsonify(error='Missing decryption key'), 400
 

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -26,6 +26,7 @@ def test_document_download(client, store):
             service_id='00000000-0000-0000-0000-000000000000',
             document_id='ffffffff-ffff-ffff-ffff-ffffffffffff',
             key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',  # 32 \x00 bytes
+            extension='pdf'
         )
     )
 
@@ -76,6 +77,7 @@ def test_force_document_download(
             service_id='00000000-0000-0000-0000-000000000000',
             document_id=document_id,
             key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',  # 32 \x00 bytes
+            extension='foo'
         )
     )
 
@@ -98,42 +100,13 @@ def test_force_document_download(
     )
 
 
-def test_document_download_with_extension(client, store):
-    store.get.return_value = {
-        'body': io.BytesIO(b'a,b,c'),
-        'mimetype': 'application/pdf',
-        'size': 100
-    }
-
-    response = client.get(
-        url_for(
-            'download.download_document',
-            service_id='00000000-0000-0000-0000-000000000000',
-            document_id='ffffffff-ffff-ffff-ffff-ffffffffffff',
-            key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',  # 32 \x00 bytes
-            extension='.pdf',
-        )
-    )
-
-    assert response.status_code == 200
-    assert response.get_data() == b'a,b,c'
-    assert dict(response.headers) == {
-        'Cache-Control': mock.ANY,
-        'Expires': mock.ANY,
-        'Content-Length': '100',
-        'Content-Type': 'application/pdf',
-        'X-B3-SpanId': 'None',
-        'X-B3-TraceId': 'None',
-        'X-Robots-Tag': 'noindex, nofollow'
-    }
-
-
 def test_document_download_without_decryption_key(client, store):
     response = client.get(
         url_for(
             'download.download_document',
             service_id='00000000-0000-0000-0000-000000000000',
             document_id='ffffffff-ffff-ffff-ffff-ffffffffffff',
+            extension='foo',
         )
     )
 
@@ -147,7 +120,8 @@ def test_document_download_with_invalid_decryption_key(client):
             'download.download_document',
             service_id='00000000-0000-0000-0000-000000000000',
             document_id='ffffffff-ffff-ffff-ffff-ffffffffffff',
-            key='🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉?'
+            key='🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉🐦⁉?',
+            extension='foo',
         )
     )
 
@@ -162,7 +136,8 @@ def test_document_download_document_store_error(client, store):
             'download.download_document',
             service_id='00000000-0000-0000-0000-000000000000',
             document_id='ffffffff-ffff-ffff-ffff-ffffffffffff',
-            key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            extension='foo',
         )
     )
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177188288

This is no longer used by the frontend [1].

We've also waited a few days and checked that no other requests have
been made to the old URL e.g. from a bookmarked URL.

[1]: https://github.com/alphagov/document-download-frontend/pull/86




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)