### PR TITLE
Add comment to explain duplicate route

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -19,6 +19,9 @@ FILE_TYPES_TO_FORCE_DOWNLOAD_FOR = ['csv', 'rtf']
 
 # Some browsers - Firefox, IE11 - use the final part of the URL as the filename when downloading a file. While we
 # don't use the extension, having it in the URL ensures the downloaded file can be opened correctly on Windows.
+#
+# The duplicate route - without the extension - is still used by some users, probably because they've bookmarked
+# the direct URL to the file. We should be able to delete this once all the old documents have expired (18 months).
 @download_blueprint.route('/services/<uuid:service_id>/documents/<uuid:document_id>.<extension>', methods=['GET'])
 @download_blueprint.route('/services/<uuid:service_id>/documents/<uuid:document_id>', methods=['GET'])
 def download_document(service_id, document_id, extension=None):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177925366

After waiting about a month, the old (non-extension) route is still
used, albeit at low volume. Since removing the route would effectively
make the documents unavailable to the user (assuming they can't find
the original email link), we should keep it for the time being.

Some supporting stats (last 7 days):

- Total requests: 149.

- Total distinct requests (by IP): 74.

Previously we had thousands of request per day.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)