### PR TITLE
Start supporting XLSX files

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -16,6 +16,7 @@ class Config(metaclass=MetaFlaskEnv):
         'text/plain': 'txt',
         'application/msword': 'doc',
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
         'application/vnd.oasis.opendocument.text': 'odt',
         'application/rtf': 'rtf',
         'text/rtf': 'rtf',

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -137,7 +137,7 @@ def test_document_upload_unknown_type(client, content_type):
     assert response.status_code == 400
     assert response.json['error'] == (
         "Unsupported file type 'application/octet-stream'. "
-        "Supported types are: '.csv', '.doc', '.docx', '.odt', '.pdf', '.rtf', '.txt'"
+        "Supported types are: '.csv', '.doc', '.docx', '.odt', '.pdf', '.rtf', '.txt', '.xlsx'"
     )
 
 

--- a/tests/utils/test_mime_types.py
+++ b/tests/utils/test_mime_types.py
@@ -13,8 +13,8 @@ from app.utils import get_mime_type
     ('test.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
     ('test.odt', 'application/vnd.oasis.opendocument.text'),
     ('test.rtf', 'text/rtf'),
-    # not supported by doc dl
     ('test.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
+    # not supported by doc dl
     ('test.pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'),
     ('test.zip', 'application/zip'),
     ('corrupted.zip', 'application/octet-stream'),


### PR DESCRIPTION
Reasoning:

While CSV is preferable to XLSX, we occasionally get requests
to support XLSX, and each time end up spending time discussing
if there is a strong enough case to support it.

We decided it is more efficient to do that work than to keep
discussing it.

Ticket:  https://www.pivotaltracker.com/story/show/177188288



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)