### PR TITLE
change runtime python version to 3.9.x

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.x
+python-3.9.x


### PR DESCRIPTION
Part of the work to upgrade all Notify apps to Python version 3.9

Should go in after: https://github.com/alphagov/notifications-aws/pull/958

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)