### PR TITLE
Catch errors due to incorrect document encoding

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -1,4 +1,4 @@
-from base64 import b64decode
+from base64 import b64decode, binascii
 from io import BytesIO
 
 from flask import Blueprint, abort, current_app, jsonify, request
@@ -20,7 +20,12 @@ def upload_document(service_id):
     if request.is_json:
         if 'document' not in request.json:
             return no_document_error
-        raw_content = b64decode(request.json['document'])
+
+        try:
+            raw_content = b64decode(request.json['document'])
+        except binascii.Error:
+            return jsonify(error='Document is not base64 encoded'), 400
+
         if len(raw_content) > current_app.config['MAX_CONTENT_LENGTH']:
             abort(413)
         file_data = BytesIO(raw_content)

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -122,6 +122,20 @@ def test_document_upload_virus_scan_error(client, store, antivirus, content_type
     }
 
 
+def test_document_upload_invalid_encoding(client):
+    response = client.post(
+        '/services/12345678-1111-1111-1111-123456789012/documents',
+        json={
+            'document': 'foo'
+        }
+    )
+
+    assert response.status_code == 400
+    assert response.json == {
+        'error': "Document is not base64 encoded"
+    }
+
+
 @pytest.mark.parametrize(
     'content_type',
     (


### PR DESCRIPTION
This can happen if someone tries to send a file without using one
of our API clients [1] and forgets to encode it properly. Also, I
can reproduce it with our Python client:

    notifications_client.send_email_notification(
      email_address='someone@example.com',
      template_id='f41db781-b608-4ed9-af6f-4d6ff3a59326',
      personalisation={ 'file_url': {'file': 'foo'} }
    )

Example stacktrace:

    Traceback (most recent call last):
      File "/home/vcap/deps/0/python/lib/python3.9/site-packages/flask/app.py", line 2447, in wsgi_app
        response = self.full_dispatch_request()
      File "/home/vcap/deps/0/python/lib/python3.9/site-packages/flask/app.py", line 1952, in full_dispatch_request
        rv = self.handle_user_exception(e)
      File "/home/vcap/deps/0/python/lib/python3.9/site-packages/flask/app.py", line 1821, in handle_user_exception
        reraise(exc_type, exc_value, tb)
      File "/home/vcap/deps/0/python/lib/python3.9/site-packages/flask/_compat.py", line 39, in reraise
        raise value
      File "/home/vcap/deps/0/python/lib/python3.9/site-packages/flask/app.py", line 1950, in full_dispatch_request
        rv = self.dispatch_request()
      File "/home/vcap/deps/0/python/lib/python3.9/site-packages/flask/app.py", line 1936, in dispatch_request
        return self.view_functions[rule.endpoint](**req.view_args)
      File "/home/vcap/app/app/upload/views.py", line 23, in upload_document
        raw_content = b64decode(request.json['document'])
      File "/home/vcap/deps/0/python/lib/python3.9/base64.py", line 87, in b64decode
        return binascii.a2b_base64(s)
    binascii.Error: Incorrect padding

The problem lies with the data sent by the user, so it makes sense
to tell them about it instead of blowing up. API will forward any
error messages on to the user [2].

[1]: https://docs.notifications.service.gov.uk/rest-api.html#upload-your-file
[2]: https://github.com/alphagov/notifications-api/blob/a165f62b6054b3ee97c7de70ab1152d4dd37a07e/app/clients/document_download.py#L11




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)