### PR TITLE
Fix "ImportError: failed to find libmagic"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ Flask-Env==2.0.0
 
 boto3==1.17.63
 
-python-magic==0.4.22
+python-magic==0.4.25
 rsa>=4.3
 
 # PaaS

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ python-dateutil==2.8.1
     #   botocore
 python-json-logger==2.0.1
     # via notifications-utils
-python-magic==0.4.22
+python-magic==0.4.25
     # via -r requirements.in
 pytz==2021.1
     # via notifications-utils


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

The changelog indicates this is due to a new Homebrew lib dir [^1].
We may as well upgrade to the latest version - all the other changes
look benign.

[^1]: https://github.com/ahupp/python-magic/blob/master/CHANGELOG#L15




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)