### PR TITLE
Bump Flask and the test dependencies

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -54,7 +54,7 @@ def download_document(service_id, document_id, extension=None):
         # rather than shown as raw text in the users browser
         send_file_kwargs.update(
             {
-                'attachment_filename': f'{document_id}.{extension}',
+                'download_name': f'{document_id}.{extension}',
                 'as_attachment': True,
             }
         )

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==1.1.2
+Flask==2.1.1
 Flask-Env==2.0.0
 
 boto3==1.17.63

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ certifi==2020.12.5
     #   requests
 chardet==4.0.0
     # via requests
-click==7.1.2
+click==8.1.2
     # via flask
 colorama==0.4.3
     # via awscli
@@ -41,7 +41,7 @@ docutils==0.15.2
     # via awscli
 eventlet==0.30.2
     # via -r requirements.in
-flask==1.1.2
+flask==2.1.1
     # via
     #   -r requirements.in
     #   flask-redis
@@ -63,11 +63,13 @@ gunicorn==20.1.0
     # via -r requirements.in
 idna==2.10
     # via requests
-itsdangerous==1.1.0
+importlib-metadata==4.11.3
+    # via flask
+itsdangerous==2.1.2
     # via
     #   flask
     #   notifications-utils
-jinja2==2.11.3
+jinja2==3.1.1
     # via
     #   flask
     #   notifications-utils
@@ -75,7 +77,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-markupsafe==1.1.1
+markupsafe==2.1.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
@@ -144,8 +146,10 @@ urllib3==1.26.4
     #   requests
 webencodings==0.5.1
     # via bleach
-werkzeug==1.0.1
+werkzeug==2.1.1
     # via flask
+zipp==3.8.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
-flake8==3.9.1
-isort==5.8.0
+flake8==4.0.1
+isort==5.10.1
 
-pytest==6.2.3
+pytest==7.1.1
 pytest-env==0.6.2
-pytest-mock==3.6.0
+pytest-mock==3.7.0
 
-requests-mock==1.9.2
+requests-mock==1.9.3
 
-jinja2-cli[yaml]==0.7.0
+jinja2-cli[yaml]==0.8.2

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -33,7 +33,7 @@ def test_document_download(client, store):
     assert response.get_data() == b'PDF document contents'
     assert dict(response.headers) == {
         'Cache-Control': mock.ANY,
-        'Expires': mock.ANY,
+        'Date': mock.ANY,
         'Content-Length': '100',
         'Content-Type': 'application/pdf',
         'X-B3-SpanId': 'None',
@@ -83,7 +83,7 @@ def test_force_document_download(
     assert response.get_data() == b'a,b,c'
     assert dict(response.headers) == {
         'Cache-Control': mock.ANY,
-        'Expires': mock.ANY,
+        'Date': mock.ANY,
         'Content-Length': '100',
         'Content-Type': expected_content_type_header,
         'Content-Disposition': f'attachment; filename={document_id}.{expected_extension}',
@@ -119,7 +119,7 @@ def test_document_download_with_extension(client, store):
     assert response.get_data() == b'a,b,c'
     assert dict(response.headers) == {
         'Cache-Control': mock.ANY,
-        'Expires': mock.ANY,
+        'Date': mock.ANY,
         'Content-Length': '100',
         'Content-Type': 'application/pdf',
         'X-B3-SpanId': 'None',


### PR DESCRIPTION
**Bump Flask to 2.1.1** 

This required one argument to `send_file` to be renamed to avoid a deprecation warning.

The other change seen, which I can't find any reference to in changelogs for Flask or Werkzeug, is that the `Expires` response header is no longer returned and a `Date` header is returned instead.

Also bumps the test dependencies.
---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)