### PR TITLE
Bump utils to 55.1.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,8 +4,6 @@
 Flask==2.1.1
 Flask-Env==2.0.0
 
-boto3==1.17.63
-
 python-magic==0.4.25
 rsa>=4.3
 
@@ -18,4 +16,4 @@ awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.2.4
 
-git+https://github.com/alphagov/notifications-utils.git@55.1.1#egg=notifications-utils==55.1.1
+git+https://github.com/alphagov/notifications-utils.git@55.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,21 +4,17 @@
 #
 #    pip-compile requirements.in
 #
-awscli==1.19.64
-    # via
-    #   awscli-cwlogs
-    #   notifications-utils
+awscli==1.22.93
+    # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
 bleach==4.1.0
     # via notifications-utils
 blinker==1.4
     # via gds-metrics
-boto3==1.17.63
-    # via
-    #   -r requirements.in
-    #   notifications-utils
-botocore==1.20.64
+boto3==1.21.38
+    # via notifications-utils
+botocore==1.24.38
     # via
     #   awscli
     #   boto3
@@ -81,7 +77,7 @@ markupsafe==2.1.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -124,7 +120,7 @@ rsa==4.7.2
     # via
     #   -r requirements.in
     #   awscli
-s3transfer==0.4.2
+s3transfer==0.5.2
     # via
     #   awscli
     #   boto3


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181588331

This required bumping the minimum version of boto3 with:

    pip-compile -P awscli requirements.in

I haven't looked into the awscli/boto3/botocore changes due to the
high churn on those libraries. Given they're minor changes we can
assume they are benign. s3transfer changes are also benign [^1]

This is also a good opportunity to remove the redundant egg spec in
the requirements, like we have in other repos.

[^1]: https://github.com/boto/s3transfer/blob/develop/CHANGELOG.rst




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)