### PR TITLE
Upgrade packages to get rid of security warnings

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,4 +15,4 @@ awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.2.4
 
-git+https://github.com/alphagov/notifications-utils.git@55.1.4
+git+https://github.com/alphagov/notifications-utils.git@55.1.6

--- a/requirements.in
+++ b/requirements.in
@@ -8,9 +8,8 @@ python-magic==0.4.25
 rsa>=4.3
 
 # PaaS
-
-gunicorn==20.1.0
-eventlet==0.30.2
+# Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
+git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 
 awscli-cwlogs>=1.4,<1.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,8 +35,8 @@ dnspython==1.16.0
     # via eventlet
 docutils==0.15.2
     # via awscli
-eventlet==0.30.2
-    # via -r requirements.in
+eventlet==0.33.0
+    # via gunicorn
 flask==2.1.1
     # via
     #   -r requirements.in
@@ -55,7 +55,7 @@ govuk-bank-holidays==0.11
     # via notifications-utils
 greenlet==1.0.0
     # via eventlet
-gunicorn==20.1.0
+gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via -r requirements.in
 idna==2.10
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ markupsafe==2.1.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -91,7 +91,7 @@ pyasn1==0.4.8
     # via rsa
 pyparsing==2.4.7
     # via packaging
-pypdf2==1.26.0
+pypdf2==1.27.12
     # via notifications-utils
 pyproj==3.2.1
     # via notifications-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -136,7 +136,7 @@ smartypants==2.0.1
     # via notifications-utils
 statsd==3.3.0
     # via notifications-utils
-urllib3==1.26.4
+urllib3==1.26.7
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
Copies [the approach taken by notifications-api](https://github.com/alphagov/notifications-api/pull/3466) to bump gunicorn and avoid the eventlet vulnerability

Upgrades notifcations-utils to bring in secure pypdf2 version

Upgrades urllib3 to a secure version

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)