### PR TITLE
Add HTTP `Referrer-Policy' as `no-referrer` to download views

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -67,6 +67,7 @@ def download_document(service_id, document_id, extension=None):
     )
     response.headers['Content-Length'] = document['size']
     response.headers['X-Robots-Tag'] = 'noindex, nofollow'
+    response.headers['Referrer-Policy'] = 'no-referrer'
 
     return response
 
@@ -107,4 +108,5 @@ def get_document_metadata(service_id, document_id):
 
     response = make_response({'document': document})
     response.headers['X-Robots-Tag'] = 'noindex, nofollow'
+    response.headers['Referrer-Policy'] = 'no-referrer'
     return response

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -36,6 +36,7 @@ def test_document_download(client, store):
         'Date': mock.ANY,
         'Content-Length': '100',
         'Content-Type': 'application/pdf',
+        'Referrer-Policy': 'no-referrer',
         'X-B3-SpanId': 'None',
         'X-B3-TraceId': 'None',
         'X-Robots-Tag': 'noindex, nofollow'
@@ -87,6 +88,7 @@ def test_force_document_download(
         'Content-Length': '100',
         'Content-Type': expected_content_type_header,
         'Content-Disposition': f'attachment; filename={document_id}.{expected_extension}',
+        'Referrer-Policy': 'no-referrer',
         'X-B3-SpanId': 'None',
         'X-B3-TraceId': 'None',
         'X-Robots-Tag': 'noindex, nofollow'
@@ -122,6 +124,7 @@ def test_document_download_with_extension(client, store):
         'Date': mock.ANY,
         'Content-Length': '100',
         'Content-Type': 'application/pdf',
+        'Referrer-Policy': 'no-referrer',
         'X-B3-SpanId': 'None',
         'X-B3-TraceId': 'None',
         'X-Robots-Tag': 'noindex, nofollow'


### PR DESCRIPTION
The referrer-policy header defines when and what should be sent
in the `Referer` header when a http request is made from clicking
a link on a page.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

When serving document files in the browser we
do not currently set the `Referrer-Policy` header. This means the
browser default is generally followed. Over the past few years browser
defaults have been changed to `strict-origin-when-cross-origin`
however this is quite a recent change and before that most used
`no-referrer-when-downgrade`.
https://developer.chrome.com/blog/referrer-policy-new-chrome-default/

This means that when clicking on any links in pdf documents served
on documents.service.gov.uk, for users using older versions of browsers
we will send the full URL including query parameters as a `Referer`
header to these links. In practice this means we are
ending up with full urls for document download files in the GOV.UK
logs under the `Referer` header. This is bad.

To stop this happening, this commit sets `Referrer-Policy' as
`no-referrer` to stop this happening.

The main route that is affected is the `download_document` route.
However I have also set the header on the `get_document_metadata`
route to be over precautious. This is because the `get_document_metadata`
route is accessible to the public with the key and although it does
not return a link (as in no `<a>` tags) it can still return a URL.
The URL is unlikely to be clickable but let us take no risks.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)