### PR TITLE
Remove notify-prometheus service binding

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -20,7 +20,6 @@ applications:
     - route: {{ hostname }}/services
 
   services:
-    - notify-prometheus
     - logit-ssl-syslog-drain
 
   env:


### PR DESCRIPTION
We have migrated to our own Prometheus metrics stack and no
longer require the gds-prometheus backing service (the service
instance is named notify-prometheus in all environments).

We have been running the new metrics stack alongside the existing
service for a few weeks and have tested and correlated collected
metrics in both systems for correctness.

Changes to the manifest are non-destructive so the service will
need to be manually unbound in each environment.

`cf unbind-service APP_NAME SERVICE_INSTANCE`
