### PR TITLE
Remove unused code from `.upload_document` endpoint

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -17,24 +17,18 @@ upload_blueprint.before_request(check_auth)
 def upload_document(service_id):
     no_document_error = jsonify(error='No document upload'), 400
 
-    if request.is_json:
-        if 'document' not in request.json:
-            return no_document_error
+    if 'document' not in request.json:
+        return no_document_error
 
-        try:
-            raw_content = b64decode(request.json['document'])
-        except binascii.Error:
-            return jsonify(error='Document is not base64 encoded'), 400
+    try:
+        raw_content = b64decode(request.json['document'])
+    except binascii.Error:
+        return jsonify(error='Document is not base64 encoded'), 400
 
-        if len(raw_content) > current_app.config['MAX_CONTENT_LENGTH']:
-            abort(413)
-        file_data = BytesIO(raw_content)
-        is_csv = request.json.get('is_csv', False)
-    else:
-        if 'document' not in request.files:
-            return no_document_error
-        file_data = request.files['document']
-        is_csv = False
+    if len(raw_content) > current_app.config['MAX_CONTENT_LENGTH']:
+        abort(413)
+    file_data = BytesIO(raw_content)
+    is_csv = request.json.get('is_csv', False)
 
     if not isinstance(is_csv, bool):
         return jsonify(error='Value for is_csv must be a boolean'), 400


### PR DESCRIPTION
The `.upload_document` endpoint was supporting content types of either 'application/json' or 'multipart/form-data' while we changed how we send files from API to document-download-api. We can now drop support for 'multipart/form-data' content since all data from API is now sent as json - https://github.com/alphagov/notifications-api/pull/2836.

Making this change helps simplify the tests for [the later story to adjust file sizes that can be uploaded](https://www.pivotaltracker.com/story/show/180461433)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)