### PR TITLE
Take base64 encoding into account in MAX_CONTENT_LENGTH check

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,5 @@
+import math
+
 from flask_env import MetaFlaskEnv
 
 
@@ -22,7 +24,9 @@ class Config(metaclass=MetaFlaskEnv):
         'text/rtf': 'rtf',
     }
 
-    MAX_CONTENT_LENGTH = 2 * 1024 * 1024 + 1024
+    # Max content length consists of 2Mb with an extra 33% to account for the increase in
+    # size after base64 encoding and an extra 1Kb buffer to account for the request headers.
+    MAX_CONTENT_LENGTH = math.floor(2 * 1024 * 1024 * 1.33 + 1024)
 
     FRONTEND_HOSTNAME = None
 

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -2,6 +2,7 @@ import base64
 from pathlib import Path
 
 import pytest
+from flask import current_app
 
 from app.utils.antivirus import AntivirusError
 
@@ -126,7 +127,7 @@ def test_document_file_size_just_right(client, store, antivirus):
     antivirus.scan.return_value = True
 
     url = '/services/12345678-1111-1111-1111-123456789012/documents'
-    file_content = b'%PDF-1.5 ' + b'a' * (2 * 1024 * 1024 - 8)
+    file_content = b'%PDF-1.5 ' + b'a' * (current_app.config['MAX_CONTENT_LENGTH'] - 9)
     response = _document_upload(client, url, file_content)
 
     assert response.status_code == 201


### PR DESCRIPTION
The `MAX_CONTENT_LENGTH` was set to 2Mb with an extra 1Kb allowed to account for the headers for the file. Base64 encoding increases the file size by [at least 133% of the size of its source](https://developer.mozilla.org/en-US/docs/Glossary/Base64#encoded_size_increase)*. This meant that someone could use one of our clients to upload a file of 1.6Mb (for example) and would get get an error - the file would pass the file size check in the client since it's smaller than 2Mb. document-download-api would then check the size of the base64 encoded file and give an error since the file is now over the limit of 2Mb.

This change increases the file size check to take into account the fact base64 encoding makes files larger.

*Note - file sizes can actually be increased a little more than 33% - they can increase by 37% if line breaks are automatically inserted when converting to base64 ([RFC2045](https://datatracker.ietf.org/doc/html/rfc2045) requires a line break to be added after every 76 characters). I haven't accounted for the extra 4% since none of our clients add line breaks. It's possible that someone could use the REST API with line breaks added but they would be very unlucky for the line breaks to push the file size over the limit.

[Pivotal story](https://www.pivotaltracker.com/story/show/180461433)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)