### PR TITLE
check octet-stream as well as zip in case they are docx/xlsx

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -12,7 +12,8 @@ def get_mime_type(document_stream):
 
     # some versions of libmagic mis-report docx, xlsx, etc. as a zip files (which they technically are),
     # so lets dive in and check the zip file headers to see if it looks like one of these.
-    if mime_type == 'application/zip':
+    # some xlsx are also misinterpreted as octet-stream on paas's version of libmagic, so check those too.
+    if mime_type in {'application/octet-stream', 'application/zip'}:
         try:
             filenames = ZipFile(BytesIO(data)).namelist()
 

--- a/tests/utils/test_mime_types.py
+++ b/tests/utils/test_mime_types.py
@@ -30,13 +30,15 @@ def test_get_mime_type(filename, expected_mime_type):
     ('test.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
     ('test.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
 ])
+@pytest.mark.parametrize('libmagic_return_value', ['application/zip', 'application/octet-stream'])
 def test_get_mime_type_zip_xml(
     filename,
     expected_mime_type,
+    libmagic_return_value,
     mocker
 ):
     # libmagic on PaaS sometimes mistakes docx, xlsx, etc. files as ZIPs
-    mocker.patch('app.utils.magic.from_buffer', return_value='application/zip')
+    mocker.patch('app.utils.magic.from_buffer', return_value=libmagic_return_value)
 
     file = open(sample_files_path / filename, 'rb')
     assert get_mime_type(file) == expected_mime_type


### PR DESCRIPTION
paas python buildpack has an old version of libmagic (5.32, you can check by running `file --version`).

We've seen a case where someone is trying to send a spreadsheet and libmagic identifies it as 'Microsoft OOXML', but when you ask for its mimetype it returns "application/octet-stream" (ie: a generic unknown binary blob). Using more up-to-date versions of libmagic on my local machine, it's identified as 'Microsoft Excel 2007+', with the mimetype correctly being 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'.

So, to mitigate this, just check octet-streams as well as application/zip to see if the might be a secret xlsx/docx file. As a reminder, xlsx/docx are zip files under the hood and we check by getting the file list for them and looking for a specific file that is only found in xlsx/docx.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)