### PR TITLE
Run antivirus scan before checking file type

### DIFF
--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -105,9 +105,10 @@ def test_document_upload_invalid_encoding(client):
     }
 
 
-def test_document_upload_unknown_type(client):
+def test_document_upload_unknown_type(client, antivirus):
     url = '/services/12345678-1111-1111-1111-123456789012/documents'
     file_content = b'\x00pdf file contents\n'
+
     response = _document_upload(client, url, file_content)
 
     assert response.status_code == 400


### PR DESCRIPTION
To check the file type we load the file into memory and inspect it. We
probably shouldn't do this before we've scanned the file and are
confident it's safe.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
