### PR TITLE
Upload hashed recipient email to S3 with document as metadata

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -52,7 +52,12 @@ def upload_document(service_id):
     if is_csv and mimetype == 'text/plain':
         mimetype = 'text/csv'
 
-    document = document_store.put(service_id, file_data, mimetype=mimetype)
+    document = document_store.put(
+        service_id,
+        file_data,
+        mimetype=mimetype,
+        verification_email=request.json.get("verification_email", None)
+    )
 
     return jsonify(
         status='ok',

--- a/requirements.in
+++ b/requirements.in
@@ -15,4 +15,6 @@ awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.2.4
 
+argon2-cffi==21.3.0
+
 git+https://github.com/alphagov/notifications-utils.git@55.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements.in
 #
+argon2-cffi==21.3.0
+    # via -r requirements.in
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
 awscli==1.22.93
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
@@ -25,6 +29,8 @@ certifi==2020.12.5
     # via
     #   pyproj
     #   requests
+cffi==1.15.1
+    # via argon2-cffi-bindings
 chardet==4.0.0
     # via requests
 click==8.1.2
@@ -89,6 +95,8 @@ prometheus-client==0.10.1
     # via gds-metrics
 pyasn1==0.4.8
     # via rsa
+pycparser==2.21
+    # via cffi
 pyparsing==2.4.7
     # via packaging
 pypdf2==1.27.12


### PR DESCRIPTION
If verification_email present in request json.

This is done so we can protect the documents from being inadvertently shared to pages like internet archive or wayback machine. User will have to confirm that they are the one meant to access the file by entering their email address. This is not as strong as password protection, but enough for the purpose.

For hashing algorithm, we chose Argon2ID based on:
https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#password-hashing-algorithms

The above docs also provided us with a choice of parameters to use.
Our memory usage is higher than our CPU usage so we chose the parameters based on that. We also explicitly set hash length, based on argon2 docs: https://argon2-cffi.readthedocs.io/en/stable/parameters.html



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
