### PR TITLE
Return `verify_email` in document metadata

### DIFF
--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -87,7 +87,8 @@ class DocumentStore:
             )
 
             return {
-                'mimetype': metadata['ContentType']
+                'mimetype': metadata['ContentType'],
+                'verify_email': True if metadata.get('Metadata', {}).get('hashed-recipient-email', None) else False
             }
         except BotoClientError as e:
             if e.response['Error']['Code'] == '404':


### PR DESCRIPTION
When we query a document's metadata, let's also return whether or not
the document has a hashed email stored against it. If it does, then
indicate that the document requires the email confirmation flow.

Ticket: https://www.pivotaltracker.com/n/projects/1443052/stories/182952340


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
