### PR TITLE
Add `/authenticate` endpoint for documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ environment.sh
 .envrc
 
 application.log.json
+
+.hypothesis

--- a/app/utils/hasher.py
+++ b/app/utils/hasher.py
@@ -1,0 +1,28 @@
+import argon2.exceptions
+from argon2 import PasswordHasher, Type
+
+
+class Hasher:
+    """
+    We use the argon2ID hasher and parameters laid out by OWASP here:
+    https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#password-hashing-algorithms
+    """
+    _hasher = PasswordHasher(
+        memory_cost=15360,
+        time_cost=2,
+        parallelism=1,
+        hash_len=16,
+        type=Type.ID
+    )
+
+    def hash(self, value: str):
+        return self._hasher.hash(value)
+
+    def verify(self, value: str, hash_to_verify: str):
+        try:
+            return self._hasher.verify(hash_to_verify, value)
+
+        except argon2.exceptions.VerifyMismatchError:
+            pass
+
+        return False

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 
 flake8==4.0.1
+hypothesis==6.54.4
 isort==5.10.1
 
 pytest==7.1.1

--- a/tests/utils/test_hasher.py
+++ b/tests/utils/test_hasher.py
@@ -1,0 +1,22 @@
+from hypothesis import given
+from hypothesis.strategies import emails
+
+from app.utils.hasher import Hasher
+
+
+class TestHasher:
+    def test_hasher_using_argon2id_with_expected_parameters(self):
+        hasher = Hasher()
+
+        hash = hasher.hash('abc123')
+
+        assert hash.startswith('$argon2id$')
+        assert '$m=15360,t=2,p=1$' in hash
+
+    @given(emails())
+    def test_hash_verifies_correctly(self, value):
+        hasher = Hasher()
+
+        hash = hasher.hash(value)
+
+        assert hasher.verify(value=value, hash_to_verify=hash)


### PR DESCRIPTION
This endpoint will be used to check that a user-submitted email address
matches the hashed one we have stored against the document in S3. If it
matches, we will return a signed blob of data encoding the service id
and document id which the frontend will store as a cookie on the user's
client. This will then be sent by the client when they try to access the
final file download URL, proving that they have successfully gone
through the authentication flow.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
