### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,14 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/PyCQA/flake8
-  rev: 4.0.1
+  rev: 5.0.4
   hooks:
-  - id: flake8 (python)
+  - id: flake8
+    name: flake8 (python)
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:
     - id: isort
       name: isort (python)
+
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: debug-statements
+- repo: https://github.com/PyCQA/flake8
+  rev: 4.0.1
+  hooks:
+  - id: flake8 (python)
+- repo: https://github.com/PyCQA/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort
+      name: isort (python)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Check the version is [runtime.txt](runtime.txt)
 
+### Pre-commit
+
+We use [pre-commit](https://pre-commit.com/) to ensure that committed code meets basic standards for formatting, and will make basic fixes for you to save time and aggravation.
+
+Install pre-commit system-wide with, eg `brew install pre-commit`. Then, install the hooks in this repository with `pre-commit install --install-hooks`.
+
 ### libmagic
 
 This is a library we use to detect file types.

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-flake8==4.0.1
+flake8==5.0.4
 hypothesis==6.54.4
 isort==5.10.1
 


### PR DESCRIPTION
We can offer pre-commit hooks to developers so that it's not possible
to commit code that breaks some basic formatting conventions.

The provided hooks for flake8 and isort will also fix issues
automatically, but reject the initial commit. Generally you can just add
the changes that the hooks have made, and then commit again, to accept
the automated fixes.

This change will do nothing by default - developers will need to opt-in
by installing the hooks.

Example:
```
sam:~/work/gds/document-download-api [SW-pre-commit]$ git commit -a
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
debug statements (python)................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

tests/download/test_views.py:12:1: E303 too many blank lines (3)

isort (python)...........................................................Failed
- hook id: isort
- files were modified by this hook

Fixing /Users/sam/work/gds/document-download-api/tests/download/test_views.py
```



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
