### PR TITLE
Add verify_email param to API return

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -106,7 +106,8 @@ def get_document_metadata(service_id, document_id):
                 document_id=document_id,
                 key=key,
                 mimetype=metadata['mimetype'],
-            )
+            ),
+            'verify_email': metadata['verify_email'],
         }
     else:
         document = None

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -217,7 +217,7 @@ def test_get_document_metadata_document_store_error(client, store):
 
 
 def test_get_document_metadata_when_document_is_in_s3(client, store):
-    store.get_document_metadata.return_value = {'mimetype': 'text/plain'}
+    store.get_document_metadata.return_value = {'mimetype': 'text/plain', 'verify_email': False}
     response = client.get(
         url_for(
             'download.get_document_metadata',
@@ -236,7 +236,8 @@ def test_get_document_metadata_when_document_is_in_s3(client, store):
                 '/services/00000000-0000-0000-0000-000000000000',
                 '/documents/ffffffff-ffff-ffff-ffff-ffffffffffff.txt',
                 '?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
-            ])
+            ]),
+            'verify_email': False,
         }
     }
 


### PR DESCRIPTION
We've implemented the verify_email return value on the document store
but aren't currently passing it out of the API response. Let's add this
so that the frontend can properly toggle on whether verification is
required or not.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
