### PR TITLE
Add size in bytes of file when getting metadata

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -106,6 +106,7 @@ def get_document_metadata(service_id, document_id):
                 mimetype=metadata['mimetype'],
             ),
             'verify_email': metadata['verify_email'],
+            'size_in_bytes': metadata['size'],
         }
     else:
         document = None

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -93,7 +93,8 @@ class DocumentStore:
 
             return {
                 'mimetype': metadata['ContentType'],
-                'verify_email': True if metadata.get('Metadata', {}).get('hashed-recipient-email', None) else False
+                'verify_email': True if metadata.get('Metadata', {}).get('hashed-recipient-email', None) else False,
+                'size': metadata['ContentLength'],
             }
         except BotoClientError as e:
             if e.response['Error']['Code'] == '404':

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -217,7 +217,7 @@ def test_get_document_metadata_document_store_error(client, store):
 
 
 def test_get_document_metadata_when_document_is_in_s3(client, store):
-    store.get_document_metadata.return_value = {'mimetype': 'text/plain', 'verify_email': False}
+    store.get_document_metadata.return_value = {'mimetype': 'text/plain', 'verify_email': False, 'size': 1024}
     response = client.get(
         url_for(
             'download.get_document_metadata',
@@ -238,6 +238,7 @@ def test_get_document_metadata_when_document_is_in_s3(client, store):
                 '?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
             ]),
             'verify_email': False,
+            'size_in_bytes': 1024,
         }
     }
 

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -19,7 +19,8 @@ def store(mocker):
     mock_boto.client.return_value.head_object.return_value = {
         'ResponseMetadata': {'RequestId': 'ABCD'},
         'Expiration': 'expiry-date="Fri, 01 May 2020 00:00:00 GMT"',
-        'ContentType': 'text/plain'
+        'ContentType': 'text/plain',
+        'ContentLength': 100
     }
     store = DocumentStore(bucket='test-bucket')
     return store
@@ -37,6 +38,7 @@ def store_with_email(mocker):
         'ResponseMetadata': {'RequestId': 'ABCD'},
         'Expiration': 'expiry-date="Fri, 01 May 2020 00:00:00 GMT"',
         'ContentType': 'text/plain',
+        'ContentLength': 100,
         'Metadata': {
             'hashed-recipient-email': (
                 # Hash of 'test@notify.example'
@@ -158,12 +160,12 @@ def test_get_document_with_boto_error(store):
 
 def test_get_document_metadata_when_document_is_in_s3(store):
     metadata = store.get_document_metadata('service-id', 'document-id', '0f0f0f')
-    assert metadata == {'mimetype': 'text/plain', 'verify_email': False}
+    assert metadata == {'mimetype': 'text/plain', 'verify_email': False, 'size': 100}
 
 
 def test_get_document_metadata_when_document_is_in_s3_with_hashed_email(store_with_email):
     metadata = store_with_email.get_document_metadata('service-id', 'document-id', '0f0f0f')
-    assert metadata == {'mimetype': 'text/plain', 'verify_email': True}
+    assert metadata == {'mimetype': 'text/plain', 'verify_email': True, 'size': 100}
 
 
 def test_get_document_metadata_when_document_is_not_in_s3(store):


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1443052/stories/183012123

This is one part of the above story which will allow the frontend to display how big the file is for the user before they download it.

This is how the frontend will use it - https://github.com/alphagov/document-download-frontend/pull/136



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
