### PR TITLE
Rename `verification_email` to `confirmation_email`

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -105,7 +105,7 @@ def get_document_metadata(service_id, document_id):
                 key=key,
                 mimetype=metadata['mimetype'],
             ),
-            'verify_email': metadata['verify_email'],
+            'confirm_email': metadata['confirm_email'],
             'size_in_bytes': metadata['size'],
         }
     else:

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -36,10 +36,10 @@ def _get_upload_document_request_data(data):
     if not isinstance(is_csv, bool):
         raise BadRequest('Value for is_csv must be a boolean')
 
-    verification_email = data.get("verification_email", None)
-    if verification_email is not None:
+    confirmation_email = data.get("confirmation_email", None)
+    if confirmation_email is not None:
         try:
-            verification_email = clean_and_validate_email_address(verification_email)
+            confirmation_email = clean_and_validate_email_address(confirmation_email)
         except InvalidEmailError as e:
             raise BadRequest(str(e))
 
@@ -50,13 +50,13 @@ def _get_upload_document_request_data(data):
         except ValueError as e:
             raise BadRequest(str(e))
 
-    return file_data, is_csv, verification_email, retention_period
+    return file_data, is_csv, confirmation_email, retention_period
 
 
 @upload_blueprint.route('/services/<uuid:service_id>/documents', methods=['POST'])
 def upload_document(service_id):
     try:
-        file_data, is_csv, verification_email, retention_period = _get_upload_document_request_data(request.json)
+        file_data, is_csv, confirmation_email, retention_period = _get_upload_document_request_data(request.json)
     except BadRequest as e:
         return jsonify(error=e.description), 400
 
@@ -83,7 +83,7 @@ def upload_document(service_id):
         service_id,
         file_data,
         mimetype=mimetype,
-        verification_email=verification_email,
+        confirmation_email=confirmation_email,
         retention_period=retention_period,
     )
 

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -22,9 +22,9 @@ class DocumentStore:
     def init_app(self, app):
         self.bucket = app.config['DOCUMENTS_BUCKET']
 
-    def put(self, service_id, document_stream, *, mimetype, verification_email=None, retention_period=None):
+    def put(self, service_id, document_stream, *, mimetype, confirmation_email=None, retention_period=None):
         """
-        verification_email and retention_period need to already be in a validated and known-good format
+        confirmation_email and retention_period need to already be in a validated and known-good format
         by the time they come into this method.
 
         returns dict {'id': 'some-uuid', 'encryption_key': b'32 byte encryption key'}
@@ -34,8 +34,8 @@ class DocumentStore:
         document_id = str(uuid.uuid4())
 
         extra_kwargs = {}
-        if verification_email:
-            hashed_recipient_email = self._hasher.hash(verification_email)
+        if confirmation_email:
+            hashed_recipient_email = self._hasher.hash(confirmation_email)
             extra_kwargs['Metadata'] = {"hashed-recipient-email": hashed_recipient_email}
 
         if retention_period:
@@ -93,7 +93,7 @@ class DocumentStore:
 
             return {
                 'mimetype': metadata['ContentType'],
-                'verify_email': True if metadata.get('Metadata', {}).get('hashed-recipient-email', None) else False,
+                'confirm_email': True if metadata.get('Metadata', {}).get('hashed-recipient-email', None) else False,
                 'size': metadata['ContentLength'],
             }
         except BotoClientError as e:

--- a/app/utils/validation.py
+++ b/app/utils/validation.py
@@ -6,11 +6,11 @@ from notifications_utils.recipients import (
 )
 
 
-def clean_and_validate_email_address(verification_email):
-    if not isinstance(verification_email, str):
-        raise InvalidEmailError('Verification email must be a string.')
+def clean_and_validate_email_address(confirmation_email):
+    if not isinstance(confirmation_email, str):
+        raise InvalidEmailError('Confirmation email must be a string.')
 
-    return validate_and_format_email_address(verification_email)
+    return validate_and_format_email_address(confirmation_email)
 
 
 def clean_and_validate_retention_period(retention_period):

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -217,7 +217,7 @@ def test_get_document_metadata_document_store_error(client, store):
 
 
 def test_get_document_metadata_when_document_is_in_s3(client, store):
-    store.get_document_metadata.return_value = {'mimetype': 'text/plain', 'verify_email': False, 'size': 1024}
+    store.get_document_metadata.return_value = {'mimetype': 'text/plain', 'confirm_email': False, 'size': 1024}
     response = client.get(
         url_for(
             'download.get_document_metadata',
@@ -237,7 +237,7 @@ def test_get_document_metadata_when_document_is_in_s3(client, store):
                 '/documents/ffffffff-ffff-ffff-ffff-ffffffffffff.txt',
                 '?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
             ]),
-            'verify_email': False,
+            'confirm_email': False,
             'size_in_bytes': 1024,
         }
     }
@@ -344,7 +344,7 @@ class TestAuthenticateDocument:
     def test_signed_data_from_successful_authentication(self, app, client, store):
         store.get_document_metadata.return_value = {
             'mimetype': 'text/csv',
-            'verify_email': True,
+            'confirm_email': True,
         }
 
         with mock.patch('app.download.views.document_store.authenticate') as authenticate_mock:

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -18,13 +18,13 @@ def antivirus(mocker):
     return mocker.patch('app.upload.views.antivirus_client')
 
 
-def _document_upload(client, url, file_content, verification_email=None, retention_period=None):
+def _document_upload(client, url, file_content, confirmation_email=None, retention_period=None):
     data = {
         'document': base64.b64encode(file_content).decode('utf-8'),
     }
 
-    if verification_email:
-        data['verification_email'] = verification_email
+    if confirmation_email:
+        data['confirmation_email'] = confirmation_email
     if retention_period:
         data['retention_period'] = retention_period
 
@@ -74,7 +74,7 @@ def test_document_upload_returns_link_to_frontend(client, store, antivirus):
     }
 
 
-def test_document_upload_sends_verification_email_on_to_document_store(
+def test_document_upload_sends_confirmation_email_on_to_document_store(
     client, store, antivirus
 ):
     store.put.return_value = {
@@ -86,12 +86,12 @@ def test_document_upload_sends_verification_email_on_to_document_store(
 
     url = '/services/00000000-0000-0000-0000-000000000000/documents'
     file_content = b'%PDF-1.4 file contents'
-    _document_upload(client, url, file_content, verification_email='user@example.com')
+    _document_upload(client, url, file_content, confirmation_email='user@example.com')
 
     # Check that the contents of the file saved is as expected
     put_args, put_kwargs = store.put.call_args_list[0]
 
-    assert put_kwargs["verification_email"] == 'user@example.com'
+    assert put_kwargs["confirmation_email"] == 'user@example.com'
 
 
 def test_document_upload_virus_found(client, store, antivirus):
@@ -320,11 +320,11 @@ def test_document_upload_bad_is_csv_value(client):
         ({'document': 'foo'}, 'Document is not base64 encoded'),
         ({'document': 'YQoxLAo=', 'is_csv': 1}, 'Value for is_csv must be a boolean'),
         (
-            {'document': 'YQoxLAo=', 'verification_email': True},
-            'Verification email must be a string.'
+            {'document': 'YQoxLAo=', 'confirmation_email': True},
+            'Confirmation email must be a string.'
         ),
         (
-            {'document': 'YQoxLAo=', 'verification_email': 'sam@foo'},
+            {'document': 'YQoxLAo=', 'confirmation_email': 'sam@foo'},
             'Not a valid email address'
         ),
         (

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -70,7 +70,7 @@ def test_document_key_with_uuid(store):
 
 def test_put_document(store):
     ret = store.put(
-        'service-id', mock.Mock(), mimetype='application/pdf', verification_email=None, retention_period=None
+        'service-id', mock.Mock(), mimetype='application/pdf', confirmation_email=None, retention_period=None
     )
 
     assert ret == {
@@ -88,9 +88,9 @@ def test_put_document(store):
     )
 
 
-def test_put_document_sends_hashed_recipient_email_to_s3_as_metadata_if_verification_email_present(store):
+def test_put_document_sends_hashed_recipient_email_to_s3_as_metadata_if_confirmation_email_present(store):
     ret = store.put(
-        'service-id', mock.Mock(), mimetype='application/pdf', verification_email="email@example.com"
+        'service-id', mock.Mock(), mimetype='application/pdf', confirmation_email="email@example.com"
     )
 
     assert ret == {
@@ -160,12 +160,12 @@ def test_get_document_with_boto_error(store):
 
 def test_get_document_metadata_when_document_is_in_s3(store):
     metadata = store.get_document_metadata('service-id', 'document-id', '0f0f0f')
-    assert metadata == {'mimetype': 'text/plain', 'verify_email': False, 'size': 100}
+    assert metadata == {'mimetype': 'text/plain', 'confirm_email': False, 'size': 100}
 
 
 def test_get_document_metadata_when_document_is_in_s3_with_hashed_email(store_with_email):
     metadata = store_with_email.get_document_metadata('service-id', 'document-id', '0f0f0f')
-    assert metadata == {'mimetype': 'text/plain', 'verify_email': True, 'size': 100}
+    assert metadata == {'mimetype': 'text/plain', 'confirm_email': True, 'size': 100}
 
 
 def test_get_document_metadata_when_document_is_not_in_s3(store):

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -11,7 +11,7 @@ def test_clean_and_validate_email_address():
     with pytest.raises(InvalidEmailError) as e:
         clean_and_validate_email_address(False)
 
-    assert str(e.value) == 'Verification email must be a string.'
+    assert str(e.value) == 'Confirmation email must be a string.'
 
 
 def test_clean_and_validate_retention_period():


### PR DESCRIPTION
We prefer the word `confirm` in our documentation and guidance, so let's keep the codebase consistent with that.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
