### PR TITLE
Add file extension to document metadata route

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -100,6 +100,7 @@ def get_document_metadata(service_id, document_id):
             ),
             "confirm_email": metadata["confirm_email"],
             "size_in_bytes": metadata["size"],
+            "file_extension": current_app.config["ALLOWED_FILE_TYPES"][metadata["mimetype"]],
         }
     else:
         document = None

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -197,8 +197,16 @@ def test_get_document_metadata_document_store_error(client, store):
     assert response.json == {"error": "something went wrong"}
 
 
-def test_get_document_metadata_when_document_is_in_s3(client, store):
-    store.get_document_metadata.return_value = {"mimetype": "text/plain", "confirm_email": False, "size": 1024}
+@pytest.mark.parametrize(
+    "mimetype, expected_extension",
+    [
+        ("text/csv", "csv"),
+        ("application/msword", "doc"),
+        ("application/pdf", "pdf"),
+    ],
+)
+def test_get_document_metadata_when_document_is_in_s3(client, store, mimetype, expected_extension):
+    store.get_document_metadata.return_value = {"mimetype": mimetype, "confirm_email": False, "size": 1024}
     response = client.get(
         url_for(
             "download.get_document_metadata",
@@ -216,12 +224,13 @@ def test_get_document_metadata_when_document_is_in_s3(client, store):
                 [
                     "http://document-download.test",
                     "/services/00000000-0000-0000-0000-000000000000",
-                    "/documents/ffffffff-ffff-ffff-ffff-ffffffffffff.txt",
+                    f"/documents/ffffffff-ffff-ffff-ffff-ffffffffffff.{expected_extension}",
                     "?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 ]
             ),
             "confirm_email": False,
             "size_in_bytes": 1024,
+            "file_extension": expected_extension,
         }
     }
 


### PR DESCRIPTION
This is so the frontend can show what type of file the user will be downloading.

I did consider sending the mimetype or the pretty file type from the API instead of the file extension. I decided to go for the file extension as
- the file extension is already information the API exposes when providing a direct link to the file
- the pretty file type, ie 'text file' or 'Microsoft Word document' feels too presentational to be the responsibility of the API
- the mimetype is more complex than the file extension to read and understand and so this makes it simpler for the frontend to use



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
