### PR TITLE
Check signed data from the cookie when downloading files

### DIFF
--- a/app/utils/signed_data.py
+++ b/app/utils/signed_data.py
@@ -1,0 +1,28 @@
+from flask import current_app
+from flask.sessions import SecureCookieSessionInterface
+from itsdangerous import BadSignature, SignatureExpired
+
+# can access for 30 days
+MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+
+
+def sign_service_and_document_id(service_id, document_id):
+    signer = SecureCookieSessionInterface().get_signing_serializer(current_app)
+    return signer.dumps(
+        {
+            "service_id": service_id,
+            "document_id": document_id,
+        }
+    )
+
+
+def verify_signed_service_and_document_id(signed_data, expected_service_id, expected_document_id):
+    signer = SecureCookieSessionInterface().get_signing_serializer(current_app)
+    try:
+        data = signer.loads(signed_data, max_age=MAX_AGE_SECONDS)
+        return data == {
+            "service_id": expected_service_id,
+            "document_id": expected_document_id,
+        }
+    except (BadSignature, SignatureExpired):
+        return False

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -120,8 +120,7 @@ class DocumentStore:
         except BotoClientError as e:
             if e.response["Error"]["Code"] == "404":
                 return False
-
-            return False
+            raise DocumentStoreError(e.response["Error"])
 
         hashed_email = self.get_email_hash(response)
 

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -12,3 +12,5 @@ pytest-mock==3.7.0
 requests-mock==1.9.3
 
 jinja2-cli[yaml]==0.8.2
+
+freezegun==1.2.2

--- a/tests/utils/test_signed_data.py
+++ b/tests/utils/test_signed_data.py
@@ -1,0 +1,33 @@
+from freezegun import freeze_time
+
+from app.utils.signed_data import (
+    sign_service_and_document_id,
+    verify_signed_service_and_document_id,
+)
+from tests.conftest import set_config
+
+
+def test_sign_service_and_document_id_can_be_verified(app):
+    ret = sign_service_and_document_id("foo", "bar")
+    assert verify_signed_service_and_document_id(ret, "foo", "bar") is True
+
+
+def test_verify_signed_service_and_document_id_returns_false_if_service_and_document_id_dont_match(app):
+    ret = sign_service_and_document_id("baz", "waz")
+    assert verify_signed_service_and_document_id(ret, "foo", "bar") is False
+
+
+def test_verify_signed_service_and_document_id_returns_false_with_old_data(app):
+    with freeze_time("2020-01-01 12:00:00"):
+        ret = sign_service_and_document_id("foo", "bar")
+    with freeze_time("2020-01-31 11:00:00"):
+        assert verify_signed_service_and_document_id(ret, "foo", "bar") is True
+    with freeze_time("2020-01-31 13:00:00"):
+        assert verify_signed_service_and_document_id(ret, "foo", "bar") is False
+
+
+def test_verify_signed_service_and_document_id_returns_false_with_malicious_data(app):
+    with set_config(app, SECRET_KEY="other value"):
+        ret = sign_service_and_document_id("foo", "bar")
+
+    assert verify_signed_service_and_document_id(ret, "foo", "bar") is False

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -215,3 +215,12 @@ def test_authenticate_fails_if_document_does_not_have_hash(store):
         mock.seal(mock_hasher)
 
         assert store.authenticate("service-id", "document-id", b"0f0f0f", "test@notify.example") is False
+
+
+def test_authenticate_with_unexpected_boto_error(store):
+    store.s3.head_object = mock.Mock(
+        side_effect=BotoClientError({"Error": {"Code": "code", "Message": "Unhandled Exception"}}, "HeadObject")
+    )
+
+    with pytest.raises(DocumentStoreError):
+        store.authenticate("service-id", "document-id", b"0f0f0f", "test@notify.example")

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -15,12 +15,14 @@ def store(mocker):
         "Body": mock.Mock(),
         "ContentType": "application/pdf",
         "ContentLength": 100,
+        "Metadata": {},
     }
     mock_boto.client.return_value.head_object.return_value = {
         "ResponseMetadata": {"RequestId": "ABCD"},
         "Expiration": 'expiry-date="Fri, 01 May 2020 00:00:00 GMT"',
         "ContentType": "text/plain",
         "ContentLength": 100,
+        "Metadata": {},
     }
     store = DocumentStore(bucket="test-bucket")
     return store
@@ -33,6 +35,12 @@ def store_with_email(mocker):
         "Body": mock.Mock(),
         "ContentType": "application/pdf",
         "ContentLength": 100,
+        "Metadata": {
+            "hashed-recipient-email": (
+                # Hash of 'test@notify.example'
+                "$argon2id$v=19$m=15360,t=2,p=1$ExyWUyRCJcqzJ+ip7SFZ2A$5SUu0QuYiF/kA9pdLsmE+A"
+            )
+        },
     }
     mock_boto.client.return_value.head_object.return_value = {
         "ResponseMetadata": {"RequestId": "ABCD"},
@@ -131,6 +139,7 @@ def test_get_document(store):
         "body": mock.ANY,
         "mimetype": "application/pdf",
         "size": 100,
+        "metadata": {},
     }
 
     store.s3.get_object.assert_called_once_with(


### PR DESCRIPTION
We authenticate users' emails with the prompt on the frontend, however, when the user clicks the link to actually download the file that's served straight from the document download API. This PR ensures that user has the cookie set earlier.

As a reminder, the cookie is set here and contains the service id and document id of the authorised document, as signed by the API[^1]. It's set on the cookie under the `document_access_signed_data`key[^2]. Because the document is served on the same domain as the admin pages, the cookie gets passed along to the api app no problem.

The flow goes as follows:

* verify the document exists and the key exists
* if the document is not authorised (as in: if it doesn't have a  hashed email in the s3 metadata)
  - **continue**
* otherwise, check for the cookie.
* if the cookie is there
  - verify the value and signature of the `document_access_signed_data` to confirm it was this app that signed the cookie, and this app signed for this specific document
    * if that's true, **continue**
  * otherwise (as in no cookie, expired cookie or bad cookie) **redirect to the beginning of the flow** to allow users to enter their email address again

i've tested this locally with happy paths for auth'd and non-auth'd docs, and also checked it works well with an expired cookie.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)

[^1]: https://github.com/alphagov/document-download-api/pull/213
[^2]: https://github.com/alphagov/document-download-frontend/pull/132