### PR TITLE
Add logging around new doc download flows

### DIFF
--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 
 import boto3
 from botocore.exceptions import ClientError as BotoClientError
+from flask import current_app
 
 from app.utils.hasher import Hasher
 
@@ -37,10 +38,14 @@ class DocumentStore:
         if confirmation_email:
             hashed_recipient_email = self._hasher.hash(confirmation_email)
             extra_kwargs["Metadata"] = {"hashed-recipient-email": hashed_recipient_email}
+            current_app.logger.info(f"Enabling email confirmation flow for {service_id}/{document_id}")
 
         if retention_period:
             tags = {"retention-period": retention_period}
             extra_kwargs["Tagging"] = urlencode(tags)
+            current_app.logger.info(
+                f"Setting custom retention period for {service_id}/{document_id}: {retention_period}"
+            )
 
         self.s3.put_object(
             Bucket=self.bucket,


### PR DESCRIPTION
Adds some logging info to document-download-api when enabling the email confirmation or setting a custom retention period, which will help in case we need to investigate anything in the coming days/weeks.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
