### PR TITLE
Get expiry date from metadata

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -134,6 +134,7 @@ def get_document_metadata(service_id, document_id):
             "confirm_email": metadata["confirm_email"],
             "size_in_bytes": metadata["size"],
             "file_extension": current_app.config["ALLOWED_FILE_TYPES"][metadata["mimetype"]],
+            "available_until": metadata["available_until"],
         }
     else:
         document = None

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -117,6 +117,10 @@ class DocumentStore:
 
         expiry_date_string = expiry_date_as_dict["expiry-date"]
 
+        timezone = expiry_date_string.split()[-1]
+        if timezone != "GMT":
+            current_app.logger.warning(f"AWS S3 object expiration has unhandled timezone: {timezone}")
+
         expiry_date = parser.parse(expiry_date_string)
         expiry_date = expiry_date.date() - timedelta(days=1)
 

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -97,10 +97,13 @@ class DocumentStore:
                 SSECustomerAlgorithm="AES256",
             )
 
+            expiry_date = self._convert_expiry_date_to_date_object(metadata["Expiration"])
+
             return {
                 "mimetype": metadata["ContentType"],
                 "confirm_email": self.get_email_hash(metadata) is not None,
                 "size": metadata["ContentLength"],
+                "available_until": str(expiry_date),
             }
         except BotoClientError as e:
             if e.response["Error"]["Code"] == "404":

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -257,7 +257,12 @@ def test_get_document_metadata_document_store_error(client, store):
     ],
 )
 def test_get_document_metadata_when_document_is_in_s3(client, store, mimetype, expected_extension):
-    store.get_document_metadata.return_value = {"mimetype": mimetype, "confirm_email": False, "size": 1024}
+    store.get_document_metadata.return_value = {
+        "mimetype": mimetype,
+        "confirm_email": False,
+        "size": 1024,
+        "available_until": "2020-04-30",
+    }
     response = client.get(
         url_for(
             "download.get_document_metadata",
@@ -282,6 +287,7 @@ def test_get_document_metadata_when_document_is_in_s3(client, store, mimetype, e
             "confirm_email": False,
             "size_in_bytes": 1024,
             "file_extension": expected_extension,
+            "available_until": "2020-04-30",
         }
     }
 

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import date
 from unittest import mock
 
 import pytest
@@ -224,3 +225,15 @@ def test_authenticate_with_unexpected_boto_error(store):
 
     with pytest.raises(DocumentStoreError):
         store.authenticate("service-id", "document-id", b"0f0f0f", "test@notify.example")
+
+
+@pytest.mark.parametrize(
+    "raw_expiry_rule,expected_date",
+    [
+        ('expiry-date="Wed, 26 Oct 2022 00:00:00 GMT", rule-id="remove-old-documents"', date(2022, 10, 25)),
+        ('expiry-date="Mon, 31 Oct 2022 00:00:00 GMT", rule-id="remove-old-documents"', date(2022, 10, 30)),
+    ],
+)
+def test___convert_expiry_date_to_date_object(raw_expiry_rule, expected_date):
+    result = DocumentStore._convert_expiry_date_to_date_object(raw_expiry_rule)
+    assert result == expected_date

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -243,3 +243,12 @@ def test_authenticate_with_unexpected_boto_error(store):
 def test___convert_expiry_date_to_date_object(raw_expiry_rule, expected_date):
     result = DocumentStore._convert_expiry_date_to_date_object(raw_expiry_rule)
     assert result == expected_date
+
+
+def test_convert_expiry_date_to_date_object_logs_on_non_gmt_expiration(app, caplog):
+    DocumentStore._convert_expiry_date_to_date_object(
+        'expiry-date="Mon, 31 Oct 2022 00:00:00 EST", rule-id="remove-old-documents"'
+    )
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message == "AWS S3 object expiration has unhandled timezone: EST"

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -20,7 +20,7 @@ def store(mocker):
     }
     mock_boto.client.return_value.head_object.return_value = {
         "ResponseMetadata": {"RequestId": "ABCD"},
-        "Expiration": 'expiry-date="Fri, 01 May 2020 00:00:00 GMT"',
+        "Expiration": 'expiry-date="Fri, 01 May 2020 00:00:00 GMT", expiry-rule="custom-retention-1-weeks"',
         "ContentType": "text/plain",
         "ContentLength": 100,
         "Metadata": {},
@@ -163,12 +163,12 @@ def test_get_document_with_boto_error(store):
 
 def test_get_document_metadata_when_document_is_in_s3(store):
     metadata = store.get_document_metadata("service-id", "document-id", "0f0f0f")
-    assert metadata == {"mimetype": "text/plain", "confirm_email": False, "size": 100}
+    assert metadata == {"mimetype": "text/plain", "confirm_email": False, "size": 100, "available_until": "2020-04-30"}
 
 
 def test_get_document_metadata_when_document_is_in_s3_with_hashed_email(store_with_email):
     metadata = store_with_email.get_document_metadata("service-id", "document-id", "0f0f0f")
-    assert metadata == {"mimetype": "text/plain", "confirm_email": True, "size": 100}
+    assert metadata == {"mimetype": "text/plain", "confirm_email": True, "size": 100, "available_until": "2020-04-30"}
 
 
 def test_get_document_metadata_when_document_is_not_in_s3(store):
@@ -230,8 +230,14 @@ def test_authenticate_with_unexpected_boto_error(store):
 @pytest.mark.parametrize(
     "raw_expiry_rule,expected_date",
     [
-        ('expiry-date="Wed, 26 Oct 2022 00:00:00 GMT", rule-id="remove-old-documents"', date(2022, 10, 25)),
+        # An expiry date in winter time (GMT) - date in GMT ISO 8601 format
         ('expiry-date="Mon, 31 Oct 2022 00:00:00 GMT", rule-id="remove-old-documents"', date(2022, 10, 30)),
+        # An expiry date in summer time (BST) - still sent by AWS in GMT ISO 8601 format.
+        ('expiry-date="Wed, 26 Oct 2022 00:00:00 GMT", rule-id="remove-old-documents"', date(2022, 10, 25)),
+        # Swap the order of the key-value pairs
+        ('rule-id="remove-old-documents", expiry-date="Mon, 31 Oct 2022 00:00:00 GMT"', date(2022, 10, 30)),
+        # Expiry date should handle month borders just fine
+        ('rule-id="remove-old-documents", expiry-date="Tue, 01 Nov 2022 00:00:00 GMT"', date(2022, 10, 31)),
     ],
 )
 def test___convert_expiry_date_to_date_object(raw_expiry_rule, expected_date):


### PR DESCRIPTION
Add `available_until` information to the returned metadata about a stored file. Once this is in, the document-download-frontend can display a message on the file download page showing how long the file will be available for.

Ticket: https://trello.com/c/kbjPobxv/13-add-date-of-file-expiry-to-doc-download-page-and-tweak-wording

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
