### PR TITLE
Return 400 (not 500) on non-ascii document

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -25,7 +25,7 @@ def _get_upload_document_request_data(data):
 
     try:
         raw_content = b64decode(data["document"])
-    except binascii.Error:
+    except (binascii.Error, ValueError):
         raise BadRequest("Document is not base64 encoded")
 
     if len(raw_content) > current_app.config["MAX_CONTENT_LENGTH"]:

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -306,6 +306,7 @@ def test_document_upload_bad_is_csv_value(client):
     (
         ({}, "No document upload"),
         ({"document": "foo"}, "Document is not base64 encoded"),
+        ({"document": "😇"}, "Document is not base64 encoded"),
         ({"document": "YQoxLAo=", "is_csv": 1}, "Value for is_csv must be a boolean"),
         ({"document": "YQoxLAo=", "confirmation_email": True}, "Confirmation email must be a string."),
         ({"document": "YQoxLAo=", "confirmation_email": "sam@foo"}, "Not a valid email address"),


### PR DESCRIPTION
At the moment, if a user sends us `file` data that isn't base64 encoded (eg isn't in the ascii charset) then we are throwing a 500. Lately we've had this error coming through in batches, which we assume is happening because the user can't recover from the error because we aren't explaining what's wrong. Let's return a better error telling them to base64 encode the file.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
