### PR TITLE
Don't fail on slower test results

### DIFF
--- a/tests/utils/test_hasher.py
+++ b/tests/utils/test_hasher.py
@@ -1,4 +1,4 @@
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import emails
 
 from app.utils.hasher import Hasher
@@ -13,6 +13,7 @@ class TestHasher:
         assert hash.startswith("$argon2id$")
         assert "$m=15360,t=2,p=1$" in hash
 
+    @settings(deadline=None)
     @given(emails())
     def test_hash_verifies_correctly(self, value):
         hasher = Hasher()


### PR DESCRIPTION
In CI/CD, if it's particularly busy, a single test run can have wildly fluctuating timings. Hypothesis doesn't like this by default and will fail the test. Let's not do that, because it makes the test very flaky.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
