### PR TITLE
Fix PyUp insecure-only version bumps. #4442

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -7,7 +7,9 @@ update: insecure
 
 search: False
 requirements:
-  - requirements-app.txt
-  - requirements-dev.txt
+  - requirements-app.txt:
+      update: insecure
+  - requirements-dev.txt:
+      update: insecure
   - requirements.txt:
       update: False


### PR DESCRIPTION
PyUp docs:

```
requirements:
  - requirements/staging.txt:
      # update all dependencies and pin them
      update: all
      pin: True
  - requirements/dev.txt:
      # don't update dependencies, use global 'pin' default
      update: False
  - requirements/prod.txt:
      # update insecure only, pin all
      update: insecure
      pin: True
```

Despite their own documentation implying settings configured at a global level apply everywhere, it's not true.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
