### PR TITLE
replace FLASK_ENV with NOTIFY_ENVIRONMENT and FLASK_DEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ bootstrap: ## install app dependencies
 
 .PHONY: run
 run-flask: ## Run the app locally
-	FLASK_APP=application.py FLASK_ENV=development flask run -p 7000
+	FLASK_APP=application.py FLASK_DEBUG=1 flask run -p 7000
 
 .PHONY: test
 test: ## Run all tests

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask
 from gds_metrics import GDSMetrics
 from notifications_utils import logging, request_helper
@@ -18,7 +20,7 @@ from .upload.views import upload_blueprint  # noqa
 
 def create_app():
     application = Flask("app")
-    application.config.from_object(configs[application.env])
+    application.config.from_object(configs[os.environ["NOTIFY_ENVIRONMENT"]])
 
     request_helper.init_app(application)
     logging.init_app(application)

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -25,7 +25,7 @@ applications:
 
   env:
     FLASK_APP: application.py
-    FLASK_ENV: {{ environment }}
+    NOTIFY_ENVIRONMENT: {{ environment }}
 
     FRONTEND_HOSTNAME: {{ hostname }}
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 testpaths = tests
 env =
-    FLASK_ENV=test
+    NOTIFY_ENVIRONMENT=test


### PR DESCRIPTION
flask_env is deprecated, so when we use it for running locally, use flask_debug to get autoreloads and stack trace, and when we use it for determining which environment we're on use NOTIFY_ENVIRONMENT instead



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
