### PR TITLE
Add dockerfile and ability to run locally using docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,17 @@ help:
 bootstrap: ## install app dependencies
 	pip install -r requirements_for_test.txt
 
+.PHONY: bootstrap-with-docker
+bootstrap-with-docker: ## Build the docker image
+	docker build -f docker/Dockerfile -t document-download-api .
+
 .PHONY: run
 run-flask: ## Run the app locally
 	FLASK_APP=application.py FLASK_DEBUG=1 flask run -p 7000
+
+.PHONY: run-flask-with-docker
+run-flask-with-docker: ## Run flask with docker
+	./scripts/run_locally_with_docker.sh
 
 .PHONY: test
 test: ## Run all tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.9-slim-bullseye
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libmagic-dev \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN groupadd -r notify && useradd -r -g notify notify
+
+WORKDIR /home/vcap/app
+
+COPY requirements.txt ./
+
+RUN echo "Installing python dependencies" \
+    && pip install -r requirements.txt
+
+COPY app app
+COPY application.py gunicorn_config.py ./
+
+RUN chown -R notify:notify /home/vcap/app
+
+USER notify

--- a/scripts/run_locally_with_docker.sh
+++ b/scripts/run_locally_with_docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eu
+
+DOCKER_IMAGE_NAME=document-download-api
+PORT=7000
+
+docker run -it --rm \
+  -e NOTIFY_ENVIRONMENT=$NOTIFY_ENVIRONMENT \
+  -e FLASK_APP=$FLASK_APP \
+  -e FLASK_DEBUG=$FLASK_DEBUG \
+  -p ${PORT}:${PORT} \
+  -v $(pwd):/home/vcap/app \
+  ${DOCKER_IMAGE_NAME} \
+  flask run --host 0.0.0.0 -p ${PORT}


### PR DESCRIPTION
The dockerfile copies https://github.com/alphagov/notifications-api/blob/main/docker/Dockerfile very closely. The main differences are
- libmagic-dev is needed as mentioned in the README for this repo
- no entrypoint script like the API because there will only be one app that we run from this docker image, not multiple like the API

I've also copied the pattern of the API with scripts/run_locally_with_docker.sh which seems OK but we can adapt later if we need to.

Worth pointing out that we don't have any instructions in the README for this repo about what environment variables are needed to run the app, in particular it appears to need at least `NOTIFY_ENVIRONMENT` but I haven't tried to document this as part of this PR. For the time being you will need to remember to pass these environment variables into the make commands in the same way you need to export them if trying to run flask without docker.

You can test this commit by
- `make bootstrap-with-docker`
- `NOTIFY_ENVIRONMENT=development FLASK_APP=application.py FLASK_DEBUG=1 make run-flask-with-docker`
- `curl localhost:7000` and you should get a 404

In production, we will instead be running a different command in the image, one using gunicorn more specifically.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
