### PR TITLE
Add support for blocking documents via S3 tagging

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,83 @@
+queues.csv
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+venv/
+venv-freeze/
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+/cache
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache
+coverage.xml
+test_results.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+.idea/
+.vscode
+
+# Mac
+*.DS_Store
+environment.sh
+.envrc
+
+celerybeat-schedule
+
+# CloudFoundry
+.cf
+
+# Tests
+/scripts/run_my_tests.sh
+
+# Local
+docker-compose.yml
+.env

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -142,6 +142,12 @@ def get_document_metadata(service_id, document_id):
     response = make_response({"document": document})
     response.headers["X-Robots-Tag"] = "noindex, nofollow"
     response.headers["Referrer-Policy"] = "no-referrer"
+
+    # Max cache duration of 30 minutes as we want to be able to re-check `blocked` tags.
+    # The `blocked` tag will still get checked when trying to download the file so this cache length isn't necessary,
+    # but will help us serve nicer pages on document-download-frontend when we know the file won't be downloadable.
+    response.cache_control.max_age = 1800
+
     return response
 
 


### PR DESCRIPTION
At the moment we have a convoluted process for blocking access to
published documents that involves an S3 bucket/object policy. This isn't
efficient or scalable (bucket policies can be at most 20kb, so
eventually this will just plain be impossible).

Let's instead allow a tag to restrict access to the file. We check for
this tag before attempting any other operations on the S3 object.

Once this is released we will be able to (still via the AWS console/boto) add a `blocked=true` tag to any objects we want to stop being downloaded, which is far cleaner than our current option using a bucket policy.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
