### PR TITLE
Don't expect ResourceType key

### DIFF
--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -50,7 +50,7 @@ class DocumentStore:
                 )["TagSet"]
             }
         except BotoClientError as e:
-            if e.response["Error"]["ResourceType"] == "DeleteMarker":
+            if e.response["Error"].get("ResourceType") == "DeleteMarker":
                 # The S3 object has been marked as expired (eg by our retention period lifecycle policy)
                 # We should treat is as not existing
                 raise DocumentExpired("The document is no longer available") from e


### PR DESCRIPTION
If we get a different kind of boto error (eg NoSucKey), there may not be a ResourceType.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
