### PR TITLE
Add service-id tag to all uploaded documents

### DIFF
--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -77,9 +77,10 @@ class DocumentStore:
             extra_kwargs["Metadata"] = {"hashed-recipient-email": hashed_recipient_email}
             current_app.logger.info(f"Enabling email confirmation flow for {service_id}/{document_id}")
 
+        tags = {"service-id": service_id}
+
         if retention_period:
-            tags = {"retention-period": retention_period}
-            extra_kwargs["Tagging"] = urlencode(tags)
+            tags["retention-period"] = retention_period
             current_app.logger.info(
                 f"Setting custom retention period for {service_id}/{document_id}: {retention_period}"
             )
@@ -91,6 +92,7 @@ class DocumentStore:
             ContentType=mimetype,
             SSECustomerKey=encryption_key,
             SSECustomerAlgorithm="AES256",
+            Tagging=urlencode(tags),
             **extra_kwargs,
         )
 

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -184,6 +184,7 @@ def test_put_document(store):
         Key=Matcher("document key", lambda x: x.startswith("service-id/") and len(x) == 11 + 36),
         SSECustomerKey=ret["encryption_key"],
         SSECustomerAlgorithm="AES256",
+        Tagging="service-id=service-id",
     )
 
 
@@ -203,6 +204,7 @@ def test_put_document_sends_hashed_recipient_email_to_s3_as_metadata_if_confirma
         SSECustomerKey=ret["encryption_key"],
         SSECustomerAlgorithm="AES256",
         Metadata={"hashed-recipient-email": mock.ANY},
+        Tagging="service-id=service-id",
     )
 
 
@@ -221,7 +223,7 @@ def test_put_document_tags_document_if_retention_period_set(store):
         Key=Matcher("document key", lambda x: x.startswith("service-id/") and len(x) == 11 + 36),
         SSECustomerKey=ret["encryption_key"],
         SSECustomerAlgorithm="AES256",
-        Tagging="retention-period=4+weeks",
+        Tagging="service-id=service-id&retention-period=4+weeks",
     )
 
 


### PR DESCRIPTION
This will allow us to generate reporting on S3 usage by service, if we ever wanted to. It can also be used eg for lifecycle management or other things. Adding it now proactively rather than with any other specific goal in mind.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
