### PR TITLE
added status endpoint for download api

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -24,6 +24,11 @@ download_blueprint = Blueprint("download", __name__, url_prefix="")
 FILE_TYPES_TO_FORCE_DOWNLOAD_FOR = ["csv", "rtf"]
 
 
+@download_blueprint.route("/services/_status")
+def status():
+    return "ok", 200
+
+
 def get_redirect_url_if_user_not_authenticated(request, document):
     # if document doesn't have hashed email, always allow unauthed access
     if "hashed-recipient-email" not in document["metadata"]:


### PR DESCRIPTION
The views.py file did not have a http based health check. Instead it had the default port type health check on PaaS. 
These lines will allow AWS ecs to run the health check on the container and get an appropriate 200 status.
---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
