### PR TITLE
Adds botocore[crt] python package and curl to the dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
     libcurl4-openssl-dev \
     libssl-dev \
     libmagic-dev \
+    curl \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 

--- a/requirements.in
+++ b/requirements.in
@@ -19,3 +19,5 @@ gds-metrics==0.2.4
 argon2-cffi==21.3.0
 
 git+https://github.com/alphagov/notifications-utils.git@55.1.6
+
+botocore[crt]==1.24.38

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,14 +12,17 @@ awscli==1.22.93
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
+awscrt==0.13.8
+    # via botocore
 bleach==4.1.0
     # via notifications-utils
 blinker==1.4
     # via gds-metrics
 boto3==1.21.38
     # via notifications-utils
-botocore==1.24.38
+botocore[crt]==1.24.38
     # via
+    #   -r requirements.in
     #   awscli
     #   boto3
     #   s3transfer


### PR DESCRIPTION

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
