### PR TITLE
Bump redis to 4.5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ argon2-cffi==21.3.0
     # via -r requirements.in
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
+async-timeout==4.0.2
+    # via redis
 awscli==1.22.93
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
@@ -122,7 +124,7 @@ pyyaml==5.4.1
     # via
     #   awscli
     #   notifications-utils
-redis==3.5.3
+redis==4.5.4
     # via flask-redis
 requests==2.25.1
     # via


### PR DESCRIPTION
Address https://nvd.nist.gov/vuln/detail/CVE-2023-28859 (doesn't apply to us anyway - we don't use async stuff)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
