### PR TITLE
Bump utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 CF_APP = document-download-api
 CF_MANIFEST_PATH ?= /tmp/manifest.yml
 
+PYTHON_EXECUTABLE_PREFIX := $(shell test -d "$${VIRTUALENV_ROOT}" && echo "$${VIRTUALENV_ROOT}/bin/" || echo "")
+
 
 ## DEVELOPMENT
 
@@ -39,6 +41,10 @@ test: ## Run all tests
 freeze-requirements: ## create static requirements.txt
 	pip install --upgrade pip-tools
 	pip-compile requirements.in
+
+.PHONY: bump-utils
+bump-utils:  # Bump notifications-utils package to latest version
+	${PYTHON_EXECUTABLE_PREFIX}python -c "from notifications_utils.version_tools import upgrade_version; upgrade_version()"
 
 ## DEPLOYMENT
 

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
-git+https://github.com/alphagov/notifications-utils.git@55.1.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.3.1
 
 botocore[crt]==1.24.38
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,6 @@ awscli-cwlogs==1.4.6
     # via -r requirements.in
 awscrt==0.13.8
     # via botocore
-bleach==4.1.0
-    # via notifications-utils
 blinker==1.4
     # via
     #   gds-metrics
@@ -94,12 +92,10 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.3.1
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
-packaging==20.9
-    # via bleach
 phonenumbers==8.12.22
     # via notifications-utils
 prometheus-client==0.10.1
@@ -108,11 +104,9 @@ pyasn1==0.4.8
     # via rsa
 pycparser==2.21
     # via cffi
-pyparsing==2.4.7
-    # via packaging
 pypdf2==2.10.6
     # via notifications-utils
-pyproj==3.2.1
+pyproj==3.5.0
     # via notifications-utils
 python-dateutil==2.8.1
     # via
@@ -150,7 +144,6 @@ shapely==1.8.1.post1
 six==1.15.0
     # via
     #   awscli-cwlogs
-    #   bleach
     #   eventlet
     #   python-dateutil
 smartypants==2.0.1
@@ -164,8 +157,6 @@ urllib3==1.26.15
     #   botocore
     #   requests
     #   sentry-sdk
-webencodings==0.5.1
-    # via bleach
 werkzeug==2.2.3
     # via
     #   -r requirements.in


### PR DESCRIPTION
This bumps us quite a lot, but is really only to pull in the change from `logger.exception` to `logger.warning` on log-formatting errors.

Here's the full changelog diff though. None of the major version bumps are 
concerning.

## 62.3.1

* Change `logger.exception` to `logger.warning` for log formatting error.

## 62.3.0

* Adds support for Chinese character sets in letters

## 62.2.1

* Injects the celery task ID into logging output if no requestId is present.

## 62.2.0

* Add odd/even class to letter pages

## 62.1.0

* Allow extra logging filters to be passed into `notifications_utils.logging.init_app`.
* Add a `UserIdFilter` to automatically inject the user_id to flask request logs.

## 62.0.1

* Include the country for normalised BFPO lines.

## 62.0.0

* Updated PostalAddress to parse BFPO addresses. Any validation done on PostalAddresses should be update to report on the new error property `has_invalid_country_for_bfpo_address`.

## 61.2.0

* Adds `redis_client.get_lock` which returns a redis lock object (or a stub lock if redis is not enabled). See https://redis-py.readthedocs.io/en/v4.4.2/lock.html for functionality.

## 61.1.0

* Adds a method to the ZendeskClient to add a comment to a pre-existing ticket, including adding attachments.

## 61.0.0

* Provide our own cache file for bank holidays data, which will help us keep it up-to-date. This is a breaking change
  as any apps pulling in utils should now use notifications_utils.bank_holidays.BankHolidays rather than
  govuk_bank_holidays.bank_holidays.BankHolidays directly.

## 60.1.0

* Add `letter_timings.is_dvla_working_day`
* Add `letter_timings.is_royal_mail_working_day`
* Add `letter_timings.get_dvla_working_day_offset_by`
* Add `letter_timings.get_previous_dvla_working_day`
* Add `letter_timings.get_royal_mail_working_day_offset_by`
* Add `letter_timings.get_previous_royal_mail_working_day`

## 60.0.0

* Bump pyproj to be version 3.4.1  or greater. This changes the ESPG codes to be upper case, which affects the how
  `Polygons` class transforms data.

## 59.3.0

* Add tooling to bump utils version in apps

## 59.2.0

* Add support for creating redis cache keys for a specific notification type.

## 59.1.0

* Add synonyms for sending letters to the Canary Islands

## 59.0.0

* Remove `Template.encoding` (very unlikely to be used anywhere)

## 58.1.0

* add a `message_as_html` parameter to `NotifySupportTicket` to enable creating tickets containing HTML (eg links).

## 58.0.0

* replace `brand_name` with `brand_alt_text` in HTMLEmailTemplate to more accurately reflect its purpose

## 57.1.0

* Do not log to file when `NOTIFY_RUNTIME_PLATFORM` is set to `ecs`

## 57.0.0

* Breaking changes to `field.Field`:

  - The `html` argument must now be `escape` or `passthrough`. `strip` is no longer
    valid
  - The default value of the `html` argument is now `escape` not `strip`

* Removal of `formatters.strip_html`:

## 56.0.0

* Breaking: upgrade PyPDF2 to version 2.0.0. You will need to:

  - Change error class imports from `pypdf2.utils` to `pypdf2.errors`.
  - Run the tests and make changes based on the deprecation warnings.

## 55.2.0

* Links in previews of text messages and emergency alerts now have the correct CSS
  classes added automatically
* URLs in previews of text messages and emergency alerts will now become links even
  if they don’t have `http://` or `https://` at the start

## 55.1.7

* Move some functions and variable from the `notifications_utils.formatters` module to
  the `notifications_utils.markdown` and `notifications_utils` modules. None of our
  apps are directly importing the functions and variables which have moved.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
