### PR TITLE
Split up `FRONTEND_HOSTNAME ` variable into two

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -68,7 +68,7 @@ class Test(Config):
     ANTIVIRUS_API_KEY = "test-antivirus-secret"
 
     FRONTEND_HOSTNAME = "document-download-frontend-test"
-    FRONTEND_HOSTNAME_INTERNAL = "document-download-frontend-test"
+    FRONTEND_HOSTNAME_INTERNAL = "document-download-frontend-internal-test"
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
     REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"

--- a/app/config.py
+++ b/app/config.py
@@ -34,6 +34,7 @@ class Config(metaclass=MetaFlaskEnv):
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024 + 1024
 
     FRONTEND_HOSTNAME = None
+    FRONTEND_HOSTNAME_INTERNAL = None
 
     NOTIFY_APP_NAME = None
     NOTIFY_LOG_PATH = "application.log"
@@ -44,7 +45,6 @@ class Config(metaclass=MetaFlaskEnv):
     ANTIVIRUS_ENABLED = True
 
     HTTP_SCHEME = "https"
-    FRONTEND_HOSTNAME = None
 
     REDIS_URL = os.getenv("REDIS_URL")
     REDIS_ENABLED = True
@@ -68,6 +68,7 @@ class Test(Config):
     ANTIVIRUS_API_KEY = "test-antivirus-secret"
 
     FRONTEND_HOSTNAME = "document-download-frontend-test"
+    FRONTEND_HOSTNAME_INTERNAL = "document-download-frontend-test"
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
     REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"
@@ -87,6 +88,7 @@ class Development(Config):
 
     HTTP_SCHEME = "http"
     FRONTEND_HOSTNAME = "localhost:7001"
+    FRONTEND_HOSTNAME_INTERNAL = "localhost:7001"
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
     REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -42,7 +42,12 @@ def get_redirect_url_if_user_not_authenticated(request, document):
         if verify_signed_service_and_document_id(signed_data, service_id, document_id):
             return
 
-    url = get_frontend_download_url(service_id, document_id, base64_to_bytes(request.args["key"]))
+    url = get_frontend_download_url(
+        service_id,
+        document_id,
+        base64_to_bytes(request.args["key"]),
+        for_internal_use=True,
+    )
 
     current_app.logger.warning(f"could not verify cookie for service {service_id} document {document_id}")
     return redirect(url)

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -15,9 +15,20 @@ def get_direct_file_url(service_id, document_id, key, mimetype):
     )
 
 
-def get_frontend_download_url(service_id, document_id, key):
+def get_frontend_download_url(service_id, document_id, key, for_internal_use=False):
+    """
+    `for_internal_use` should be set to True when we are getting the document-download-frontend
+    url in order to call it from this app. If it will be used externally or displayed it should
+    be kept as False
+    """
     scheme = current_app.config["HTTP_SCHEME"]
     netloc = current_app.config["FRONTEND_HOSTNAME"]
+
+    if for_internal_use:
+        netloc = current_app.config["FRONTEND_HOSTNAME_INTERNAL"]
+    else:
+        netloc = current_app.config["FRONTEND_HOSTNAME"]
+
     path = "d/{}/{}".format(uuid_to_base64(service_id), uuid_to_base64(document_id))
     query = urlencode({"key": bytes_to_base64(key)})
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -28,6 +28,7 @@ applications:
     NOTIFY_ENVIRONMENT: {{ environment }}
 
     FRONTEND_HOSTNAME: {{ hostname }}
+    FRONTEND_HOSTNAME_INTERNAL: {{ hostname }}
 
     NOTIFY_APP_NAME: document-download-api
     NOTIFY_LOG_PATH: /home/vcap/logs/app.log

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -499,7 +499,7 @@ class TestGetRedirectUrlIfUserNotAuthenticated:
         redirect = get_redirect_url_if_user_not_authenticated(mock_request, mock_doc_store_get_response)
         assert redirect.location == "".join(
             [
-                "https://document-download-frontend-test",
+                "https://document-download-frontend-internal-test",
                 "/d/AAAAAAAAAAAAAAAAAAAAAA",
                 "/_____________________w",
                 "?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -514,7 +514,7 @@ class TestGetRedirectUrlIfUserNotAuthenticated:
         redirect = get_redirect_url_if_user_not_authenticated(mock_request, mock_doc_store_get_response)
         assert redirect.location == "".join(
             [
-                "https://document-download-frontend-test",
+                "https://document-download-frontend-internal-test",
                 "/d/AAAAAAAAAAAAAAAAAAAAAA",
                 "/_____________________w",
                 "?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -15,6 +15,14 @@ def test_get_frontend_download_url_returns_frontend_url(app):
     )
 
 
+def test_get_frontend_download_url_when_internal_url_is_requested(app):
+    assert get_frontend_download_url(
+        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY, for_internal_use=True
+    ) == "https://document-download-frontend-internal-test/d/{}/{}?key={}".format(
+        "AAAAAAAAAAAAAAAAAAAAAA", "AAAAAAAAAAAAAAAAAAAAAQ", SAMPLE_B64
+    )
+
+
 def test_get_direct_file_url_gets_local_url_without_compressing_uuids(app):
     assert get_direct_file_url(
         service_id=UUID(int=0),


### PR DESCRIPTION
**Add new environment variable for `FRONTEND_HOSTNAME_INTERNAL`**
When the apps are deployed in ECS we want to use the internal routes where possible. We use the `FRONTEND_HOSTNAME` in two places, but only one of these needs to use the public route. This adds a new variable, `FRONTEND_HOSTNAME_INTERNAL`, which will be used when calling document-download-frontend from within the app. When deployed on the PaaS both environment variables should have the same value.

**Call doc-download-frontend using internal route when possible**
When we get the URL for document-download-frontend in order to immediately redirect there we can use the internal route for the app. When we return the URL of a document we should still use the external route.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
