### PR TITLE
Add version file make step; tag release for sentry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 SHELL := /bin/bash
+DATE = $(shell date +%Y-%m-%d:%H:%M:%S)
+
+APP_VERSION_FILE = app/version.py
+
+GIT_BRANCH ?= $(shell git symbolic-ref --short HEAD 2> /dev/null || echo "detached")
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
 
 CF_API ?= api.cloud.service.gov.uk
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
@@ -16,11 +22,11 @@ help:
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: bootstrap
-bootstrap: ## install app dependencies
+bootstrap: generate-version-file ## install app dependencies
 	pip install -r requirements_for_test.txt
 
 .PHONY: bootstrap-with-docker
-bootstrap-with-docker: ## Build the docker image
+bootstrap-with-docker: generate-version-file ## Build the docker image
 	docker build -f docker/Dockerfile -t document-download-api .
 
 .PHONY: run
@@ -45,6 +51,10 @@ freeze-requirements: ## create static requirements.txt
 .PHONY: bump-utils
 bump-utils:  # Bump notifications-utils package to latest version
 	${PYTHON_EXECUTABLE_PREFIX}python -c "from notifications_utils.version_tools import upgrade_version; upgrade_version()"
+
+.PHONY: generate-version-file
+generate-version-file: ## Generates the app version file
+	@echo -e "__git_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
 ## DEPLOYMENT
 

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,1 @@
+version.py

--- a/app/performance.py
+++ b/app/performance.py
@@ -26,6 +26,13 @@ def init_performance_monitoring():
 
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 
+        try:
+            from app.version import __git_commit__
+
+            release = __git_commit__
+        except ImportError:
+            release = None
+
         sentry_sdk.init(
             dsn=sentry_dsn,
             environment=environment,
@@ -33,4 +40,5 @@ def init_performance_monitoring():
             send_default_pii=send_pii,
             request_bodies=send_request_bodies,
             traces_sampler=traces_sampler,
+            release=release,
         )


### PR DESCRIPTION
Copies the 'generate-version-file' step that we have in API and admin, and uses that (if possible) when initialising Sentry. This will let us track releases and tie errors to new releases.

We'll need to update the deployment pipeline to generate this file, but that can happen separately.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
