### PR TITLE
Add deploy-exclude.lst

### DIFF
--- a/deploy-exclude.lst
+++ b/deploy-exclude.lst
@@ -1,0 +1,5 @@
+*__pycache__*
+.git/*
+venv/*
+.envrc
+.cf/*


### PR DESCRIPTION
We use this file in all of the other apps to exclude files from the zip archive that is used to deploy our apps.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
