### PR TITLE
Remove duplicate variable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,8 +33,6 @@ class Config(metaclass=MetaFlaskEnv):
 
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024 + 1024
 
-    FRONTEND_HOSTNAME = None
-
     NOTIFY_APP_NAME = None
     NOTIFY_LOG_PATH = "application.log"
 


### PR DESCRIPTION
We had `FRONTEND_HOSTNAME` listed twice in the same class.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
