### PR TITLE
Add subdomain route for preview

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -18,6 +18,9 @@ applications:
   routes:
     - route: document-download-api-{{ environment }}.cloudapps.digital
     - route: {{ hostname }}/services
+    {% if hostname == "preview" %}
+    - route: download.{{ hostname }}
+    {% endif %}
 
   services:
     - logit-ssl-syslog-drain


### PR DESCRIPTION
Related pr: https://github.com/alphagov/notifications-aws/pull/1451


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
