### PR TITLE
Remove new preview route to unblock pipeline

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -19,7 +19,7 @@ applications:
     - route: document-download-api-{{ environment }}.cloudapps.digital
     - route: {{ hostname }}/services
     {% if environment == "preview" %}
-    - route: download.{{ hostname }}
+    #- route: download.{{ hostname }}
     {% endif %}
 
   services:


### PR DESCRIPTION
Initially this was failing with this error:

    For application 'document-download-api': No domains exist for route download.documents.notify.works

When trying to create the `documents.notify.works` domain in cf we got:

    The domain name "documents.notify.works" cannot be created because "documents.notify.works" is already reserved by a route

Trying to create the `download.documents.notify.works` domain in cf we got:

    The domain name "download.documents.notify.works" cannot be created because "documents.notify.works" is already reserved by a route

The answer probably lies somewhere here: https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#parent-child-domains



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
