### PR TITLE
Update `DOCUMENTS_BUCKET` value for preview

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -91,7 +91,9 @@ class Development(Config):
 
 
 class Preview(Config):
-    DOCUMENTS_BUCKET = "preview-document-download"
+    # When running on ECS we set the MULTIREGION_ACCESSPOINT_ARN since we access the bucket
+    # through the multiregion accesspoint
+    DOCUMENTS_BUCKET = os.getenv("MULTIREGION_ACCESSPOINT_ARN", "preview-document-download")
 
 
 class Staging(Config):


### PR DESCRIPTION
When the apps run on ECS we need to connect to the S3 bucket via the multiregion accesspoint - we can't just put objects in S3 directly like we can when running on the PaaS. This change lets us optionally set a new variable, `MULTIREGION_ACCESSPOINT_ARN`, for running on ECS. If set, this should be the value of the accesspoint arn.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
