### PR TITLE
Fix requirements (unable to freeze)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,6 @@ argon2-cffi==21.3.0
 
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.0.0
 
-botocore[crt]==1.24.38
+botocore[crt]==1.31.7
 
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,19 +10,19 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 async-timeout==4.0.2
     # via redis
-awscli==1.22.93
+awscli==1.29.7
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
-awscrt==0.13.8
+awscrt==0.16.26
     # via botocore
 blinker==1.4
     # via
     #   gds-metrics
     #   sentry-sdk
-boto3==1.21.38
+boto3==1.28.5
     # via notifications-utils
-botocore[crt]==1.24.38
+botocore[crt]==1.31.7
     # via
     #   -r requirements.in
     #   awscli
@@ -118,7 +118,7 @@ python-magic==0.4.25
     # via -r requirements.in
 pytz==2021.1
     # via notifications-utils
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   awscli
     #   notifications-utils
@@ -133,7 +133,7 @@ rsa==4.7.2
     # via
     #   -r requirements.in
     #   awscli
-s3transfer==0.5.2
+s3transfer==0.6.1
     # via
     #   awscli
     #   boto3


### PR DESCRIPTION
For the last few days we've been unable to run `make freeze-requirements`, getting errors like this:

```
...
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
...
pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1

make: *** [freeze-requirements] Error 1
```

From some searches online this seems related to a release of cython3 that just came out, which PyYAML uses.

yaml/pyyaml#724

There is now a new release of PyYAML (6.0.1) that fixes the issue, so let's bump to that. In order to bump to that, we need to bump boto3, botocore, awscrt and s3transfer as well.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
