### PR TITLE
Flask-OpenAPI3

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 import os
 
+from flask import jsonify
 from flask_openapi3 import Info, OpenAPI
 from gds_metrics import GDSMetrics
 from notifications_utils import logging, request_helper
@@ -59,6 +60,9 @@ def create_app():
         # We override pydantic's native validation errors with our custom one so that we can return a 400 instead of
         # a 422, which is what flask-openapi3 returns. We don't have this behaviour on Notify and so 400 is more
         # consistent with what we would expect.
-        return error.validation_error.json(), 400, {"content-type": "application/json"}
+        if error.override_message:
+            return jsonify(error=error.override_message), 400
+
+        return error.original_error.json(), 400
 
     return application

--- a/app/openapi.py
+++ b/app/openapi.py
@@ -1,0 +1,39 @@
+import uuid
+from typing import Optional
+
+from flask_openapi3 import Tag
+from pydantic import BaseModel, Field
+
+healthcheck_tag = Tag(name="healthcheck")
+download_tag = Tag(name="download")
+upload_tag = Tag(name="upload")
+
+
+class DownloadPath(BaseModel):
+    service_id: uuid.UUID = Field(description="The service UUID")
+    document_id: uuid.UUID = Field(description="The document UUID")
+
+
+class DownloadQuery(BaseModel):
+    base64_key: Optional[str] = Field(alias="key", description="The encryption key protecting the document")
+
+
+class DownloadBody(BaseModel):
+    base64_key: Optional[str] = Field(alias="key", description="The encryption key protecting the document")
+    email_address: Optional[str] = Field(description="The email address associated with the document on upload")
+
+
+class UploadPath(BaseModel):
+    service_id: uuid.UUID = Field(description="The service UUID")
+
+
+class UploadJson(BaseModel):
+    base64_document: str = Field(alias="document", description="Base64-encoded file to store")
+    is_csv: Optional[bool] = Field(description="Is the file a CSV?")
+    confirmation_email: Optional[str] = Field(
+        default="my@email.com",
+        description="If set, the user will need to enter their email address before the file can be downloaded.",
+    )
+    retention_period: Optional[str] = Field(
+        description="How long to retain the file for, in the format '<1-72> weeks'", default="26 weeks"
+    )

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -22,9 +22,6 @@ upload_blueprint.before_request(check_auth)
 
 
 def _get_upload_document_request_data(data: UploadJson):
-    if data.base64_document is None:
-        raise BadRequest("No document upload")
-
     try:
         raw_content = b64decode(data.base64_document)
     except (binascii.Error, ValueError) as e:

--- a/requirements.in
+++ b/requirements.in
@@ -21,3 +21,5 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66
 botocore[crt]==1.31.7
 
 sentry_sdk[flask]>=1.0.0,<2.0.0
+
+flask-openapi3

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,11 +52,14 @@ eventlet==0.33.0
 flask==2.2.5
     # via
     #   -r requirements.in
+    #   flask-openapi3
     #   flask-redis
     #   gds-metrics
     #   notifications-utils
     #   sentry-sdk
 flask-env==2.0.0
+    # via -r requirements.in
+flask-openapi3==2.4.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
@@ -106,6 +109,8 @@ pyasn1==0.4.8
     # via rsa
 pycparser==2.21
     # via cffi
+pydantic==1.10.11
+    # via flask-openapi3
 pypdf==3.13.0
     # via notifications-utils
 pyproj==3.5.0
@@ -155,7 +160,9 @@ smartypants==2.0.1
 statsd==3.3.0
     # via notifications-utils
 typing-extensions==4.7.1
-    # via pypdf
+    # via
+    #   pydantic
+    #   pypdf
 urllib3==1.26.15
     # via
     #   botocore

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -304,11 +304,8 @@ def test_document_upload_bad_is_csv_value(client):
 @pytest.mark.parametrize(
     "data, expected_error",
     (
-        ({}, "No document upload"),
         ({"document": "foo"}, "Document is not base64 encoded"),
         ({"document": "😇"}, "Document is not base64 encoded"),
-        ({"document": "YQoxLAo=", "is_csv": 1}, "Value for is_csv must be a boolean"),
-        ({"document": "YQoxLAo=", "confirmation_email": True}, "Confirmation email must be a string."),
         ({"document": "YQoxLAo=", "confirmation_email": "sam@foo"}, "Not a valid email address"),
         (
             {"document": "YQoxLAo=", "retention_period": True},

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -2,8 +2,8 @@ import base64
 from pathlib import Path
 
 import pytest
-from werkzeug.exceptions import BadRequest
 
+from app.openapi import UploadJson
 from app.upload.views import _get_upload_document_request_data
 from app.utils.antivirus import AntivirusError
 
@@ -321,7 +321,7 @@ def test_document_upload_bad_is_csv_value(client):
     ),
 )
 def test_get_upload_document_request_data_errors(app, data, expected_error):
-    with pytest.raises(BadRequest) as e:
-        _get_upload_document_request_data(data)
+    with pytest.raises(Exception) as e:
+        _get_upload_document_request_data(UploadJson(**data))
 
     assert e.value.description == expected_error


### PR DESCRIPTION
Testing out a flask framework extension that integrates Pydantic and OpenAPI doc generation.

This gives us an accessible page at `/services/openapi` where you can get a UI playground to explore and interact with the API, eg:

![image](https://github.com/alphagov/document-download-api/assets/2920760/78b55f3d-60be-4881-a814-56a5231c2d39)