### PR TITLE
Bump utils

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,9 +8,7 @@ werkzeug==2.2.3
 python-magic==0.4.25
 rsa>=4.3
 
-# PaaS
-# Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
-git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
+gunicorn[eventlet]>=21.2.0
 
 awscli-cwlogs>=1.4,<1.5
 

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
 
 botocore[crt]==1.31.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ govuk-bank-holidays==0.11
     # via notifications-utils
 greenlet==1.0.0
     # via eventlet
-gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
+gunicorn[eventlet]==21.2.0
     # via -r requirements.in
 idna==2.10
     # via requests
@@ -96,6 +96,8 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
+packaging==23.1
+    # via gunicorn
 phonenumbers==8.12.22
     # via notifications-utils
 prometheus-client==0.10.1
@@ -165,6 +167,3 @@ werkzeug==2.2.3
     #   flask
 zipp==3.16.1
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -104,7 +104,7 @@ pyasn1==0.4.8
     # via rsa
 pycparser==2.21
     # via cffi
-pypdf2==2.10.6
+pypdf==3.13.0
     # via notifications-utils
 pyproj==3.5.0
     # via notifications-utils
@@ -137,6 +137,8 @@ s3transfer==0.6.1
     # via
     #   awscli
     #   boto3
+segno==1.5.2
+    # via notifications-utils
 sentry-sdk[flask]==1.21.1
     # via -r requirements.in
 shapely==1.8.1.post1
@@ -151,7 +153,7 @@ smartypants==2.0.1
 statsd==3.3.0
     # via notifications-utils
 typing-extensions==4.7.1
-    # via pypdf2
+    # via pypdf
 urllib3==1.26.15
     # via
     #   botocore


### PR DESCRIPTION
And unpin gunicorn now that a newer release is out (func tests look good: https://concourse.notify.tools/teams/notify/pipelines/apps/jobs/functional-tests-document-download-preview/builds/148)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
