### PR TITLE
Add `download.` route across all environments

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -18,9 +18,7 @@ applications:
   routes:
     - route: document-download-api-{{ environment }}.cloudapps.digital
     - route: {{ hostname }}/services
-    {% if environment == "preview" %}
-    #- route: download.{{ hostname }}
-    {% endif %}
+    - route: download.{{ hostname }}
 
   services:
     - logit-ssl-syslog-drain


### PR DESCRIPTION
Bind the `donwload.` subdomain as route across all environments.

This will *not* serve any traffic yet.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
