### PR TITLE
Allow configuration of SERVER_NAME env var for all environments

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,7 @@ if os.environ.get("VCAP_SERVICES"):
 
 
 class Config(metaclass=MetaFlaskEnv):
+    SERVER_NAME = os.getenv("SERVER_NAME")
     DEBUG = False
 
     SECRET_KEY = os.environ.get("SECRET_KEY")
@@ -72,7 +73,6 @@ class Test(Config):
 
 
 class Development(Config):
-    SERVER_NAME = os.getenv("SERVER_NAME")
     DEBUG = True
 
     SECRET_KEY = "secret-key"


### PR DESCRIPTION
We think we will need this for the ECS app to provide external links to itself

https://trello.com/c/Qy4JgJDD/293-make-the-document-download-functional-tests-pass



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
