### PR TITLE
Change how `get_direct_file_url` generates URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -57,7 +57,7 @@ class Test(Config):
     DEBUG = True
 
     # used during tests as a domain name
-    SERVER_NAME = "document-download.test"
+    SERVER_NAME = "download.document-download-frontend-test"
 
     SECRET_KEY = "test-secret"
     AUTH_TOKENS = "test-token:test-token-2"

--- a/app/config.py
+++ b/app/config.py
@@ -66,6 +66,7 @@ class Test(Config):
     ANTIVIRUS_API_HOST = "https://test-antivirus"
     ANTIVIRUS_API_KEY = "test-antivirus-secret"
 
+    HTTP_SCHEME = "http"
     FRONTEND_HOSTNAME = "document-download-frontend-test"
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")

--- a/app/config.py
+++ b/app/config.py
@@ -56,9 +56,6 @@ class Config(metaclass=MetaFlaskEnv):
 class Test(Config):
     DEBUG = True
 
-    # used during tests as a domain name
-    SERVER_NAME = "download.document-download-frontend-test"
-
     SECRET_KEY = "test-secret"
     AUTH_TOKENS = "test-token:test-token-2"
 
@@ -69,7 +66,7 @@ class Test(Config):
 
     HTTP_SCHEME = "http"
     FRONTEND_HOSTNAME = "document-download-frontend-test"
-    DOCUMENT_DOWNLOAD_API_HOSTNAME = "download.document-download-frontend-test"
+    DOCUMENT_DOWNLOAD_API_HOSTNAME = f"download.{FRONTEND_HOSTNAME}"
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
     REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"

--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,7 @@ class Config(metaclass=MetaFlaskEnv):
 
     HTTP_SCHEME = "https"
     FRONTEND_HOSTNAME = None
+    DOCUMENT_DOWNLOAD_API_HOSTNAME = None
 
     REDIS_URL = os.getenv("REDIS_URL")
     REDIS_ENABLED = True
@@ -68,6 +69,7 @@ class Test(Config):
 
     HTTP_SCHEME = "http"
     FRONTEND_HOSTNAME = "document-download-frontend-test"
+    DOCUMENT_DOWNLOAD_API_HOSTNAME = "download.document-download-frontend-test"
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
     REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"
@@ -87,6 +89,7 @@ class Development(Config):
 
     HTTP_SCHEME = "http"
     FRONTEND_HOSTNAME = "localhost:7001"
+    DOCUMENT_DOWNLOAD_API_HOSTNAME = "localhost:7000"
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
     REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -5,14 +5,16 @@ from notifications_utils.base64_uuid import bytes_to_base64, uuid_to_base64
 
 
 def get_direct_file_url(service_id, document_id, key, mimetype):
-    return url_for(
+    path = url_for(
         "download.download_document",
         service_id=service_id,
         document_id=document_id,
         key=bytes_to_base64(key),
         extension=current_app.config["ALLOWED_FILE_TYPES"][mimetype],
-        _external=True,
+        _external=False,
     )
+
+    return f"{current_app.config['HTTP_SCHEME']}://{current_app.config['DOCUMENT_DOWNLOAD_API_HOSTNAME']}{path}"
 
 
 def get_frontend_download_url(service_id, document_id, key):

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -29,6 +29,7 @@ applications:
     NOTIFY_ENVIRONMENT: {{ environment }}
 
     FRONTEND_HOSTNAME: {{ hostname }}
+    DOCUMENT_DOWNLOAD_API_HOSTNAME: download.{{ hostname }}
 
     NOTIFY_APP_NAME: document-download-api
     NOTIFY_LOG_PATH: /home/vcap/logs/app.log

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def app():
 @pytest.fixture()
 def client(app):
 
-    with app.test_client() as client:
+    with app.test_request_context(), app.test_client() as client:
         yield client
 
 

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -278,7 +278,7 @@ def test_get_document_metadata_when_document_is_in_s3(client, store, mimetype, e
         "document": {
             "direct_file_url": "".join(
                 [
-                    "http://document-download.test",
+                    "http://download.document-download-frontend-test",
                     "/services/00000000-0000-0000-0000-000000000000",
                     f"/documents/ffffffff-ffff-ffff-ffff-ffffffffffff.{expected_extension}",
                     "?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -415,7 +415,7 @@ class TestAuthenticateDocument:
 
         assert response.status_code == 200
         assert direct_file_url == (
-            "http://document-download.test/"
+            "http://download.document-download-frontend-test/"
             "services/00000000-0000-0000-0000-000000000000/"
             "documents/ffffffff-ffff-ffff-ffff-ffffffffffff.csv"
             "?key=sP09NZwxDwl3DE2j1bj0jCTbBjpeLkGiJ_rq788NWHM"

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -466,16 +466,15 @@ class TestGetRedirectUrlIfUserNotAuthenticated:
         }
 
     @pytest.fixture
-    def mock_request(self, app, mocker):
-        with app.test_request_context():
-            mock_request = mocker.patch("app.download.views.request")
-            mock_request.view_args = {
-                "service_id": "00000000-0000-0000-0000-000000000000",
-                "document_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-            }
-            mock_request.args = {"key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}
-            mock_request.cookies = {"document_access_signed_data": "foo bar baz"}
-            yield mock_request
+    def mock_request(self, client, mocker):
+        mock_request = mocker.patch("app.download.views.request")
+        mock_request.view_args = {
+            "service_id": "00000000-0000-0000-0000-000000000000",
+            "document_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        }
+        mock_request.args = {"key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}
+        mock_request.cookies = {"document_access_signed_data": "foo bar baz"}
+        yield mock_request
 
     def test_it_returns_none_if_document_not_secured(self, mocker, mock_request, mock_doc_store_get_response):
         mock_verify = mocker.patch("app.download.views.verify_signed_service_and_document_id")

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -499,7 +499,7 @@ class TestGetRedirectUrlIfUserNotAuthenticated:
         redirect = get_redirect_url_if_user_not_authenticated(mock_request, mock_doc_store_get_response)
         assert redirect.location == "".join(
             [
-                "https://document-download-frontend-test",
+                "http://document-download-frontend-test",
                 "/d/AAAAAAAAAAAAAAAAAAAAAA",
                 "/_____________________w",
                 "?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -514,7 +514,7 @@ class TestGetRedirectUrlIfUserNotAuthenticated:
         redirect = get_redirect_url_if_user_not_authenticated(mock_request, mock_doc_store_get_response)
         assert redirect.location == "".join(
             [
-                "https://document-download-frontend-test",
+                "http://document-download-frontend-test",
                 "/d/AAAAAAAAAAAAAAAAAAAAAA",
                 "/_____________________w",
                 "?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -55,7 +55,7 @@ def test_document_upload_returns_link_to_frontend(client, store, antivirus):
             "id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
             "url": "".join(
                 [
-                    "https://document-download-frontend-test",
+                    "http://document-download-frontend-test",
                     "/d/AAAAAAAAAAAAAAAAAAAAAA",
                     "/_____________________w",
                     "?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -266,7 +266,7 @@ def test_document_upload_csv_handling(
             "id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
             "url": "".join(
                 [
-                    "https://document-download-frontend-test",
+                    "http://document-download-frontend-test",
                     "/d/AAAAAAAAAAAAAAAAAAAAAA",
                     "/_____________________w",
                     "?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -63,7 +63,7 @@ def test_document_upload_returns_link_to_frontend(client, store, antivirus):
             ),
             "direct_file_url": "".join(
                 [
-                    "http://document-download.test",
+                    "http://download.document-download-frontend-test",
                     "/services/00000000-0000-0000-0000-000000000000",
                     "/documents/ffffffff-ffff-ffff-ffff-ffffffffffff.pdf",
                     "?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -275,7 +275,7 @@ def test_document_upload_csv_handling(
             "mimetype": expected_mimetype,
             "direct_file_url": "".join(
                 [
-                    "http://document-download.test",
+                    "http://download.document-download-frontend-test",
                     "/services/00000000-0000-0000-0000-000000000000",
                     "/documents/ffffffff-ffff-ffff-ffff-ffffffffffff",
                     f'.{app.config["ALLOWED_FILE_TYPES"][expected_mimetype]}',

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -10,7 +10,7 @@ SAMPLE_B64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
 def test_get_frontend_download_url_returns_frontend_url(app):
     assert get_frontend_download_url(
         service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY
-    ) == "https://document-download-frontend-test/d/{}/{}?key={}".format(
+    ) == "http://document-download-frontend-test/d/{}/{}?key={}".format(
         "AAAAAAAAAAAAAAAAAAAAAA", "AAAAAAAAAAAAAAAAAAAAAQ", SAMPLE_B64
     )
 

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -21,7 +21,7 @@ def test_get_direct_file_url_gets_local_url_without_compressing_uuids(app):
         document_id=UUID(int=1),
         key=SAMPLE_KEY,
         mimetype="text/plain",
-    ) == "http://document-download.test/services/{}/documents/{}.{}?key={}".format(
+    ) == "http://download.document-download-frontend-test/services/{}/documents/{}.{}?key={}".format(
         "00000000-0000-0000-0000-000000000000",
         "00000000-0000-0000-0000-000000000001",
         "txt",

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -15,7 +15,7 @@ def test_get_frontend_download_url_returns_frontend_url(app):
     )
 
 
-def test_get_direct_file_url_gets_local_url_without_compressing_uuids(app):
+def test_get_direct_file_url_gets_local_url_without_compressing_uuids(client):
     assert get_direct_file_url(
         service_id=UUID(int=0),
         document_id=UUID(int=1),


### PR DESCRIPTION
When the app is deployed on the PaaS, document-download-frontend calls document-download-api on its public route and the `get_direct_file_url` function generates a URL using that public route. On ECS, document-download-frontend will use the private route, which results in the URLs generated using the private domains which we don't want.

We now create an environment variable, `DOCUMENT_DOWNLOAD_API_HOSTNAME`, and use when generating the URL of the file.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
