### PR TITLE
Always use DB 1, regardless of which redis we are using

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -5,6 +5,8 @@ import os
 def extract_cloudfoundry_config():
     vcap_services = json.loads(os.environ["VCAP_SERVICES"])
 
-    # Redis config - use DB 1 to separate logically from Notify - as likely to re-use the same redis instance
     if "REDIS_URL" not in os.environ:
-        os.environ["REDIS_URL"] = vcap_services["redis"][0]["credentials"]["uri"] + "/1"
+        os.environ["REDIS_URL"] = vcap_services["redis"][0]["credentials"]["uri"]
+
+    # Redis config - use DB 1 to separate logically from Notify - as likely to re-use the same redis instance
+    os.environ["REDIS_URL"] = os.environ["REDIS_URL"] + "/1"


### PR DESCRIPTION
We realised our previous PR was only adding the `/1` for the redis URL provided by VCAP services. We also want to add the `/1` for the redis URL provided by the REDIS_URL environment variable (ie we have set it in our credentials repo).



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
