### PR TITLE
Set 90 second gunicorn keepalive

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -4,13 +4,10 @@ import socket
 import eventlet
 from gds_metrics.gunicorn import child_exit  # noqa
 
-bind = "0.0.0.0:{}".format(os.getenv("PORT"))
-
 workers = 4
-
 worker_class = "eventlet"
 worker_connections = 1000
-
+bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 errorlog = "/home/vcap/logs/gunicorn_error.log"
 
 

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -9,6 +9,7 @@ worker_class = "eventlet"
 worker_connections = 1000
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 errorlog = "/home/vcap/logs/gunicorn_error.log"
+keepalive = 90
 
 
 def fix_ssl_monkeypatching():

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -2,6 +2,7 @@ import os
 import socket
 
 import eventlet
+import gunicorn
 from gds_metrics.gunicorn import child_exit  # noqa
 
 workers = 4
@@ -9,6 +10,7 @@ worker_class = "eventlet"
 worker_connections = 1000
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 errorlog = "/home/vcap/logs/gunicorn_error.log"
+gunicorn.SERVER_SOFTWARE = "None"
 keepalive = 90
 
 


### PR DESCRIPTION
Review commit by commit but essentially
- small spacing tidy up
- set 90 second keepalive to match https://github.com/alphagov/notifications-admin/pull/4826
---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
