### PR TITLE
disable redis on staging

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -100,6 +100,7 @@ class Preview(Config):
 
 class Staging(Config):
     DOCUMENTS_BUCKET = "staging-document-download"
+    REDIS_ENABLED = False
 
 
 class Production(Config):


### PR DESCRIPTION
This PR is part of a set of PRs to be merged during the proposed migration of PaaS apps to start using redis from notify-staging
The steps agreed on the document are:

Change Credentials REPO - This PR adds the redis_url to the credentials repo
Disable redis (by setting REDIS_ENABLED to false on API, ADMIN and DOCUMENT_DOWNLOAD_API)
Enable redis (by setting REDIS_ENABLED to true on API, ADMIN and DOCUMENT_DOWNLOAD_API
---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
