### PR TITLE
Revert "Switch to use cflinuxfs4"

### DIFF
--- a/manifest-droplet.yml
+++ b/manifest-droplet.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: ((app_name))
-  stack: cflinuxfs4
+  stack: cflinuxfs3
   processes:
   - type: web
     instances: 0

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -6,8 +6,6 @@ applications:
 
   instances: 2
 
-  stack: cflinuxfs4
-
   buildpacks:
     - python_buildpack
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -6,6 +6,8 @@ applications:
 
   instances: 2
 
+  stack: cflinuxfs3
+
   buildpacks:
     - python_buildpack
 


### PR DESCRIPTION
Reverts alphagov/document-download-api#273

The change of the underlying OS has pulled in an updated version of libmagic, which is detecting JSON better, resulting in us rejecting JSON data.

Doing this as a quick fix while we investigate and fix more properly.

### cflinuxfs3

```
vcap@cf5c2aad-e255-4091-60d2-d144:~$ apt show libmagic1
Package: libmagic1
Version: 1:5.32-2ubuntu0.4
Status: install ok installed
Priority: optional
Section: libs
Source: file
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Christoph Biedl <debian.axhn@manchmal.in-ulm.de>
Installed-Size: 204 kB
Depends: libc6 (>= 2.15), zlib1g (>= 1:1.1.4), libmagic-mgc (= 1:5.32-2ubuntu0.4)
Suggests: file
Homepage: http://www.darwinsys.com/file/
Download-Size: unknown
APT-Manual-Installed: yes
APT-Sources: /var/lib/dpkg/status
Description: Recognize the type of data in a file using "magic" numbers - library
 This library can be used to classify files according to magic number
 tests. It implements the core functionality of the file command.
```

```
vcap@cf5c2aad-e255-4091-60d2-d144:~$ flask shell
{"name": "app", "levelname": "INFO", "message": "Logging configured", "pathname": "/home/vcap/deps/0/python/lib/python3.9/site-packages/notifications_utils/logging.py", "lineno": 42, "user_id": null, "time": "2023-09-25T14:59:18", "requestId": "no-request-id", "application": "document-download-api", "service_id": "no-service-id", "logType": "application"}
Python 3.9.17 (main, Jun  6 2023, 14:22:15)
[GCC 7.5.0] on linux
App: app
Instance: /home/vcap/app/instance
>>> import magic
>>> magic.from_buffer(b'{"key": "value", "some": "json", "look": ["at", "me"]}', mime=True)
'text/plain'
```

### cflinuxfs4

```
apvcap@e51fb4c8-6ec7-4d86-5aaf-86d8:~$ apt show libmagic1
Package: libmagic1
Version: 1:5.41-3
Priority: standard
Section: libs
Source: file
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Christoph Biedl <debian.axhn@manchmal.in-ulm.de>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 233 kB
Depends: libbz2-1.0, libc6 (>= 2.33), liblzma5 (>= 5.1.1alpha+20120614), zlib1g (>= 1:1.1.4), libmagic-mgc (= 1:5.41-3)
Suggests: file
Homepage: https://www.darwinsys.com/file/
Task: standard
Download-Size: 87.2 kB
APT-Manual-Installed: yes
APT-Sources: http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages
Description: Recognize the type of data in a file using "magic" numbers - library
```

```
vcap@e51fb4c8-6ec7-4d86-5aaf-86d8:~$ flask shell
{"name": "app", "levelname": "INFO", "message": "Logging configured", "pathname": "/home/vcap/deps/0/python/lib/python3.9/site-packages/notifications_utils/logging.py", "lineno": 42, "user_id": null, "time": "2023-09-25T14:58:34", "requestId": "no-request-id", "application": "document-download-api", "service_id": "no-service-id", "logType": "application"}
Python 3.9.17 (main, Jun  6 2023, 14:20:14)
[GCC 11.3.0] on linux
App: app
Instance: /home/vcap/app/instance
>>> import magic
>>> magic.from_buffer(b'{"key": "value", "some": "json", "look": ["at", "me"]}', mime=True)
'application/json'
```