### PR TITLE
Set `REDIS_ENABLED` env var in the manifest if one is defined

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -53,3 +53,6 @@ applications:
     {% if REDIS_URL is defined %}
     REDIS_URL: '{{ REDIS_URL }}'
     {% endif %}
+    {% if REDIS_ENABLED is defined %}
+    REDIS_ENABLED: '{{ REDIS_ENABLED }}'
+    {% endif %}


### PR DESCRIPTION

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
