### PR TITLE
Config cleanup

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -88,7 +88,6 @@ class Development(Config):
     DOCUMENT_DOWNLOAD_API_HOSTNAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOSTNAME", "localhost:7000")
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
-    REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"
 
     NOTIFY_RUNTIME_PLATFORM = "local"
 

--- a/app/config.py
+++ b/app/config.py
@@ -43,8 +43,8 @@ class Config:
     FRONTEND_HOSTNAME = os.environ.get("FRONTEND_HOSTNAME")
     DOCUMENT_DOWNLOAD_API_HOSTNAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOSTNAME")
 
-    # use DB 1 to separate logically from Notify - as likely to re-use the same redis instance
-    REDIS_URL = os.getenv("REDIS_URL") + "/1" if os.getenv("REDIS_URL") else None
+    REDIS_URL = os.getenv("REDIS_URL")
+
     REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"
 
     DOCUMENT_AUTHENTICATION_RATE_LIMIT = int(os.getenv("DOCUMENT_AUTHENTICATION_RATE_LIMIT", "50"))

--- a/app/config.py
+++ b/app/config.py
@@ -1,14 +1,12 @@
 import os
 
-from flask_env import MetaFlaskEnv
 
-
-class Config(metaclass=MetaFlaskEnv):
+class Config:
     SERVER_NAME = os.getenv("SERVER_NAME")
     DEBUG = False
 
     SECRET_KEY = os.environ.get("SECRET_KEY")
-    AUTH_TOKENS = None
+    AUTH_TOKENS = os.environ.get("AUTH_TOKENS")
 
     DOCUMENTS_BUCKET = None
 
@@ -31,23 +29,23 @@ class Config(metaclass=MetaFlaskEnv):
     MAX_DECODED_FILE_SIZE = (2 * 1024 * 1024) + 1024  # ~2MiB: Enforced by us - max file size after b64decode
     MAX_CUSTOM_FILENAME_LENGTH = 100
 
-    NOTIFY_APP_NAME = None
-    NOTIFY_LOG_PATH = "application.log"
+    NOTIFY_APP_NAME = os.environ.get("NOTIFY_APP_NAME")
+    NOTIFY_LOG_PATH = os.environ.get("NOTIFY_LOG_PATH", "application.log")
 
     NOTIFY_RUNTIME_PLATFORM = os.getenv("NOTIFY_RUNTIME_PLATFORM", "paas")
 
-    ANTIVIRUS_API_HOST = None
-    ANTIVIRUS_API_KEY = None
+    ANTIVIRUS_API_HOST = os.environ.get("ANTIVIRUS_API_HOST")
+    ANTIVIRUS_API_KEY = os.environ.get("ANTIVIRUS_API_KEY")
 
     ANTIVIRUS_ENABLED = True
 
     HTTP_SCHEME = "https"
-    FRONTEND_HOSTNAME = None
-    DOCUMENT_DOWNLOAD_API_HOSTNAME = None
+    FRONTEND_HOSTNAME = os.environ.get("FRONTEND_HOSTNAME")
+    DOCUMENT_DOWNLOAD_API_HOSTNAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOSTNAME")
 
     # use DB 1 to separate logically from Notify - as likely to re-use the same redis instance
     REDIS_URL = os.getenv("REDIS_URL") + "/1" if os.getenv("REDIS_URL") else None
-    REDIS_ENABLED = False if os.environ.get("REDIS_ENABLED") == "0" else True
+    REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"
 
     DOCUMENT_AUTHENTICATION_RATE_LIMIT = int(os.getenv("DOCUMENT_AUTHENTICATION_RATE_LIMIT", "50"))
     DOCUMENT_AUTHENTICATE_RATE_INTERVAL_SECONDS = int(os.getenv("DOCUMENT_AUTHENTICATE_RATE_INTERVAL_SECONDS", "300"))
@@ -68,8 +66,7 @@ class Test(Config):
     FRONTEND_HOSTNAME = "document-download-frontend-test"
     DOCUMENT_DOWNLOAD_API_HOSTNAME = f"download.{FRONTEND_HOSTNAME}"
 
-    REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
-    REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"
+    REDIS_URL = "redis://localhost:6379/1"
 
     NOTIFY_RUNTIME_PLATFORM = "test"
 
@@ -87,8 +84,8 @@ class Development(Config):
     ANTIVIRUS_ENABLED = False
 
     HTTP_SCHEME = "http"
-    FRONTEND_HOSTNAME = "localhost:7001"
-    DOCUMENT_DOWNLOAD_API_HOSTNAME = "localhost:7000"
+    FRONTEND_HOSTNAME = os.environ.get("FRONTEND_HOSTNAME", "localhost:7001")
+    DOCUMENT_DOWNLOAD_API_HOSTNAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOSTNAME", "localhost:7000")
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
     REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -49,4 +49,5 @@ applications:
     SENTRY_DSN: '{{ DOCUMENT_DOWNLOAD_API_SENTRY_DSN }}'
     SENTRY_ERRORS_SAMPLE_RATE: '{{ DOCUMENT_DOWNLOAD_API_SENTRY_ERRORS_SAMPLE_RATE }}'
     SENTRY_TRACES_SAMPLE_RATE: '{{ DOCUMENT_DOWNLOAD_API_SENTRY_TRACES_SAMPLE_RATE }}'
-    REDIS_URL: '{{ REDIS_URL }}'
+    # note the os environment variable name is different to the variable name in the creds repo
+    REDIS_URL: '{{ REDIS_DOCUMENT_DOWNLOAD_URL }}'

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,6 @@
 # with package version changes made in requirements-app.txt
 
 Flask==3.0.0
-Flask-Env==2.0.0
 werkzeug==3.0.1
 
 python-magic==0.4.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,8 +54,6 @@ flask==3.0.0
     #   gds-metrics
     #   notifications-utils
     #   sentry-sdk
-flask-env==2.0.0
-    # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
 gds-metrics==0.2.4


### PR DESCRIPTION
## [remove flask-env](https://github.com/alphagov/document-download-api/pull/292/commits/dd4755b14d7e152ef5a5300d769c16c7005f2fd1) 

flask-env makes it easy to run in to bugs where we think we're defining environment variable defaults but they're actually not used (for example, the REDIS_URL having a `/1` doesnt actually work because that just sets a value that flask-env then overwrites with the URL from the env later.

by removing it and just reading the env manually we can make our configs easier to reason about

## [expect REDIS_URL to contain a /1 domain](https://github.com/alphagov/document-download-api/pull/292/commits/0a4226aa586baca3009ce869aa62d9175631cf78) 

previously, we expected to be passed in a REDIS_URL that looked like `rediss://some-domain:6379`, which we'd add `/1` to to use the second database contained on the redis server.

However we now use REDIS_DOCUMENT_DOWNLOAD_URL, which contains a /1 domain (and is defined variously in credentials for paas and in terraform for ecs).


Requires this to be merged first: 

- [x] https://github.com/alphagov/notifications-credentials/pull/414


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
