### PR TITLE
Change Dockerfile to use multi-stage builds and let tests be run in Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ bootstrap: generate-version-file ## install app dependencies
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker: generate-version-file ## Build the docker image
-	docker build -f docker/Dockerfile -t document-download-api .
+	docker build -f docker/Dockerfile --target test -t document-download-api .
 
 .PHONY: run
 run-flask: ## Run the app locally
@@ -35,13 +35,17 @@ run-flask: ## Run the app locally
 
 .PHONY: run-flask-with-docker
 run-flask-with-docker: ## Run flask with docker
-	./scripts/run_locally_with_docker.sh
+	FLASK_APP=application.py FLASK_DEBUG=1 ./scripts/run_locally_with_docker.sh flask run --host 0.0.0.0 -p 7000
 
 .PHONY: test
 test: ## Run all tests
 	ruff check .
 	black --check .
 	py.test tests/
+
+.PHONY: test-with-docker
+test-with-docker: ## Run tests in Docker container
+	FLASK_APP=application.py FLASK_DEBUG=1 ./scripts/run_locally_with_docker.sh make test
 
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,10 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.9-slim-bullseye AS base
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    build-essential \
-    git \
     libcurl4-openssl-dev \
     libssl-dev \
     libmagic-dev \
@@ -14,18 +12,72 @@ RUN apt-get update \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN groupadd -r notify && useradd -r -g notify notify
-
 WORKDIR /home/vcap/app
+
+##### Python Build Image #####################################################
+FROM base AS python_build
+
+RUN echo "Install OS dependencies for python app requirements" &&  \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
 
 COPY requirements.txt ./
 
-RUN echo "Installing python dependencies" \
-    && pip install -r requirements.txt
+RUN echo "Installing python dependencies" && \
+    python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install -r requirements.txt
 
-COPY app app
-COPY application.py gunicorn_config.py ./
+COPY . .
+RUN make generate-version-file  # This file gets copied across
+
+##### Production Image #######################################################
+FROM base AS production
+
+RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap
+USER notify
+
+RUN mkdir /home/vcap/logs
+
+COPY --from=python_build --chown=root:root /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+COPY --chown=notify:notify app app
+COPY --chown=notify:notify application.py gunicorn_config.py ./
+COPY --from=python_build --chown=notify:notify /home/vcap/app/app/version.py app/version.py
 
 RUN chown -R notify:notify /home/vcap/app
 
+##### Test Image ##############################################################
+FROM production as test
+
+USER root
+RUN echo "Install OS dependencies for test build" \
+    && apt-get update && \
+    apt-get install -y --no-install-recommends \
+      sudo \
+      curl \
+      git \
+      make \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+RUN usermod -aG sudo notify
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER notify
+
+# Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
+RUN mkdir -p app
+
+# Copying to overwrite is faster than RUN chown notify:notify ...
+COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
+
+# Install dev/test requirements
+COPY --chown=notify:notify Makefile requirements.txt requirements_for_test.txt ./
+RUN make bootstrap
+
+# Copy from the real world, one dir up (project root) into the environment's current working directory
+# Docker will rebuild from here down every time.
+COPY --chown=notify:notify . .

--- a/scripts/run_locally_with_docker.sh
+++ b/scripts/run_locally_with_docker.sh
@@ -11,4 +11,4 @@ docker run -it --rm \
   -p ${PORT}:${PORT} \
   -v $(pwd):/home/vcap/app \
   ${DOCKER_IMAGE_NAME} \
-  flask run --host 0.0.0.0 -p ${PORT}
+  ${@}


### PR DESCRIPTION
We want to be able to run the tests in Docker since we saw differences in behaviour when running the app in Docker (on ECS) vs on the PaaS. The Dockerfile cannot be used for this without changes since it doesn't install any test dependencies.

This changes the Dockerfile to use multi-stage builds and to be as consistent as possible with those we have in other apps.

We can then run the tests in Docker

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
