### PR TITLE
Change how we set `DOCUMENTS_BUCKET` in Staging and Production

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -94,11 +94,11 @@ class Preview(Config):
 
 
 class Staging(Config):
-    DOCUMENTS_BUCKET = "staging-document-download"
+    DOCUMENTS_BUCKET = os.getenv("MULTIREGION_ACCESSPOINT_ARN", "staging-document-download")
 
 
 class Production(Config):
-    DOCUMENTS_BUCKET = "production-document-download"
+    DOCUMENTS_BUCKET = os.getenv("MULTIREGION_ACCESSPOINT_ARN", "production-document-download")
 
 
 configs = {


### PR DESCRIPTION
When running on ECS we set `DOCUMENTS_BUCKET` to be the `MULTIREGION_ACCESSPOINT_ARN` since we access the bucket through the multiregion accesspoint. We had made this change to preview, but this changes staging and production to match.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
