### PR TITLE
Upgrade to bookworm and add a longer CSV file for testing

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -74,7 +74,7 @@ def upload_document(service_id):
         allowed_file_types = ", ".join(sorted({f"'.{x}'" for x in current_app.config["ALLOWED_FILE_TYPES"].values()}))
         return jsonify(error=f"Unsupported file type '{mimetype}'. Supported types are: {allowed_file_types}"), 400
 
-    # Our mimetype auto-detection resolves CSV content as text/plain, so we use
+    # Our mimetype auto-detection sometimes resolves CSV content as text/plain, so we use
     # an explicit POST body parameter `is_csv` from the caller to resolve it as text/csv
     if is_csv and mimetype == "text/plain":
         mimetype = "text/csv"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye AS base
+FROM python:3.9-slim-bookworm AS base
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1

--- a/tests/sample_files/test_longer.csv
+++ b/tests/sample_files/test_longer.csv
@@ -1,0 +1,4 @@
+colour,number
+green,three
+blue,four
+red,seven

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -203,6 +203,21 @@ def test_unauthorized_document_upload(client):
             "text/plain",
         ),
         (
+            "test_longer.csv",
+            {"is_csv": True},
+            "text/csv",
+        ),
+        (
+            "test_longer.csv",
+            {"is_csv": False},
+            "text/csv",
+        ),
+        (
+            "test_longer.csv",
+            {},
+            "text/csv",
+        ),
+        (
             "test.txt",
             {"is_csv": True},
             "text/csv",

--- a/tests/utils/test_mime_types.py
+++ b/tests/utils/test_mime_types.py
@@ -13,6 +13,7 @@ sample_files_path = Path(__file__).parent.parent / "sample_files"
         # supported by doc dl
         ("test.pdf", "application/pdf"),
         ("test.csv", "text/plain"),
+        ("test_longer.csv", "text/csv"),
         ("test.doc", "application/msword"),
         ("test.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
         ("test.odt", "application/vnd.oasis.opendocument.text"),


### PR DESCRIPTION
**Add tests for a longer CSV file**
The test CSV file is very short (just one word) and we've seen slightly different behaviour with longer CSV files. This adds a second, longer, CSV file to the tests.

The behaviour of the two files in `test_document_upload_csv_handling` in inconsistent but this matches the current behaviour.

**Upgrade Dockerfile to use bookworm**
When this was using bullseye we were using libmagic-dev version 5.39 which has a known bug where CSV files can be identified as "application/csv" instead of registered "text/csv". By upgrading to Bookworm we get a later version of libmagic-dev without the bug.

After this change, the tests pass with Docker.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
