### PR TITLE
requirements: notifications-utils: 66.0.0 -> 73.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
 
 botocore[crt]==1.31.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,13 +94,13 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
 packaging==23.1
     # via gunicorn
-phonenumbers==8.12.22
+phonenumbers==8.13.26
     # via notifications-utils
 prometheus-client==0.10.1
     # via gds-metrics


### PR DESCRIPTION
https://trello.com/c/Q5S5m4ge/446-add-http-logging-to-all-of-our-ecs-apps

See https://github.com/alphagov/notifications-utils/pull/1077, this should bring flask request logging to apps in desired circumstances.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
