### PR TITLE
requirements: notifications-utils: 66.0.0 -> 74.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
 
 botocore[crt]==1.31.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,6 @@ cachetools==4.2.2
     # via notifications-utils
 certifi==2023.7.22
     # via
-    #   pyproj
     #   requests
     #   sentry-sdk
 cffi==1.15.1
@@ -94,13 +93,13 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
     # via -r requirements.in
-orderedset==2.0.3
+ordered-set==4.1.0
     # via notifications-utils
 packaging==23.1
     # via gunicorn
-phonenumbers==8.12.22
+phonenumbers==8.13.26
     # via notifications-utils
 prometheus-client==0.10.1
     # via gds-metrics
@@ -109,8 +108,6 @@ pyasn1==0.4.8
 pycparser==2.21
     # via cffi
 pypdf==3.17.0
-    # via notifications-utils
-pyproj==3.5.0
     # via notifications-utils
 python-dateutil==2.8.1
     # via
@@ -145,8 +142,6 @@ segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
     # via -r requirements.in
-shapely==1.8.1.post1
-    # via notifications-utils
 six==1.15.0
     # via
     #   awscli-cwlogs


### PR DESCRIPTION
https://trello.com/c/Q5S5m4ge/446-add-http-logging-to-all-of-our-ecs-apps

See https://github.com/alphagov/notifications-utils/pull/1077, this should bring flask request logging to apps in desired circumstances.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
