### PR TITLE
Install mime-support for extension lookups

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     libssl-dev \
     libmagic-dev \
     curl \
+    mime-support \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 


### PR DESCRIPTION
When document-download-api is running via its Dockerfile (ECS), we didn't have any mimetype files available. This change installs the package, which creates `/etc/mime.types`, which Python's `mimetypes` package reads.

This allows us to lookup all of the file extensions we support and convert them to mimetypes.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
