### PR TITLE
Limit custom filename length

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,7 @@ class Config(metaclass=MetaFlaskEnv):
 
     MAX_CONTENT_LENGTH = 3 * 1024 * 1024  # 3MiB: Enforced by Flask/Werkzeug to generously allow for b64 size inflation
     MAX_DECODED_FILE_SIZE = (2 * 1024 * 1024) + 1024  # ~2MiB: Enforced by us - max file size after b64decode
+    MAX_CUSTOM_FILENAME_LENGTH = 100
 
     NOTIFY_APP_NAME = None
     NOTIFY_LOG_PATH = "application.log"

--- a/app/utils/validation.py
+++ b/app/utils/validation.py
@@ -39,6 +39,11 @@ def clean_and_validate_retention_period(retention_period):
 
 
 def validate_filename(filename):
+    if len(filename) > current_app.config["MAX_CUSTOM_FILENAME_LENGTH"]:
+        raise ValueError(
+            f"`filename` cannot be longer than {current_app.config['MAX_CUSTOM_FILENAME_LENGTH']} characters"
+        )
+
     if "." not in filename:
         raise ValueError("`filename` must end with a file extension. For example, filename.csv")
 

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -35,6 +35,15 @@ def test_validate_filename_happy_path(client, filename):
     assert validate_filename(filename) == filename
 
 
+def test_validate_filename_length(client):
+    validate_filename(("a" * 96) + ".csv")
+
+    with pytest.raises(ValueError) as e:
+        validate_filename(("a" * 97) + ".csv")
+
+    assert str(e.value) == "`filename` cannot be longer than 100 characters"
+
+
 def test_validate_filename_needs_dot():
     with pytest.raises(ValueError) as e:
         validate_filename("my-filename")


### PR DESCRIPTION
AWS S3 (User defined) metadata is limited to 2 KB in PUT requests, so we should make sure we're not using it all. I also want to not let filenames use the majority of it so that there's still space for us to use it for other things in the future, if we want.

By limiting filename length to 100 characters, we will in theory be allowing up to 580 bytes for the filename, assuming the extension (`.csv` takes up four and is always ASCII). The rest of the name could be unicode characters, which through encoding are converted to \Uxxxx - ie 6 bytes. So in the worst case, 96 UTF-8 characters will become 576 bytes. This is the extreme outlier, as I expect most filenames will be fully or mainly ASCII, so normally up to 100 bytes.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
