### PR TITLE
Change package for `/etc/mime.types`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     libssl-dev \
     libmagic-dev \
     curl \
-    mime-support \
+    media-types \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 


### PR DESCRIPTION
From https://wiki.debian.org/mime-support

The `mime-support` package was split into two packages: `media-types`
and `mailcap`. `media-types` now provides the `/etc/mime.types` file.
`mailcap` associates media types with programs that can support them -
we don't need that, so we can probably just use `media-types` instead.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
