### PR TITLE
Bump utils to 74.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
 
 botocore[crt]==1.31.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
 ## 74.4.0

* Reverts the 'single session' change from 74.1.0, which may be causing us some connection errors.

 ## 74.3.0

* Add `decrby` method to the RedisClient

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.2.0...74.4.0



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
