### PR TITLE
Enable automatic download of txt files

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -22,7 +22,7 @@ from app.utils.validation import clean_and_validate_email_address
 
 download_blueprint = Blueprint("download", __name__, url_prefix="")
 
-FILE_TYPES_TO_FORCE_DOWNLOAD_FOR = ["csv", "rtf"]
+FILE_TYPES_TO_FORCE_DOWNLOAD_FOR = ["csv", "rtf", "txt"]
 
 
 @download_blueprint.route("/services/_status")

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -90,6 +90,7 @@ def test_download_document_with_authenticated_user(client, store):
     [
         ("text/csv", "csv", "text/csv; charset=utf-8"),
         ("text/rtf", "rtf", "text/rtf; charset=utf-8"),
+        ("text/plain", "txt", "text/plain; charset=utf-8"),
         ("application/rtf", "rtf", "application/rtf"),
     ],
 )


### PR DESCRIPTION
We currently enforce automatic downloads of `csv` and `rtf` files. This PR does the same for `txt `files. 
---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
