### PR TITLE
AntivirusClient: include onwards request headers in requests

### DIFF
--- a/app/utils/antivirus.py
+++ b/app/utils/antivirus.py
@@ -1,5 +1,6 @@
 import requests
-from flask import current_app
+from flask import current_app, request
+from flask.ctx import has_request_context
 
 
 class AntivirusError(Exception):
@@ -29,12 +30,14 @@ class AntivirusClient:
         self.auth_token = app.config["ANTIVIRUS_API_KEY"]
 
     def scan(self, document_stream):
+        headers = {"Authorization": "Bearer {}".format(self.auth_token)}
+        if has_request_context() and hasattr(request, "get_onwards_request_headers"):
+            headers.update(request.get_onwards_request_headers())
+
         try:
             response = requests.post(
                 "{}/scan".format(self.api_host),
-                headers={
-                    "Authorization": "Bearer {}".format(self.auth_token),
-                },
+                headers=headers,
                 files={"document": document_stream},
             )
 

--- a/tests/utils/test_antivirus.py
+++ b/tests/utils/test_antivirus.py
@@ -3,21 +3,53 @@ import io
 import pytest
 import requests
 import requests_mock
+from notifications_utils.testing.comparisons import AnySupersetOf
 
 from app.utils.antivirus import AntivirusClient, AntivirusError
+from tests.conftest import set_config
 
 
 @pytest.fixture(scope="function")
-def antivirus(client, mocker):
+def app_antivirus(app):
     client = AntivirusClient()
-    current_app = mocker.Mock(
-        config={"ANTIVIRUS_API_HOST": "https://antivirus", "ANTIVIRUS_API_KEY": "test-antivirus-key"}
+    with set_config(
+        app,
+        ANTIVIRUS_API_HOST="https://antivirus",
+        ANTIVIRUS_API_KEY="test-antivirus-key",
+    ):
+        client.init_app(app)
+        yield app, client
+
+
+def test_scan_document(mocker, app_antivirus):
+    app, antivirus = app_antivirus
+    mocker.patch(
+        "notifications_utils.request_helper.NotifyRequest.get_onwards_request_headers",
+        return_value={"some-onwards": "request-header"},
     )
-    client.init_app(current_app)
-    return client
+    document = io.BytesIO(b"filecontents")
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(
+            "https://antivirus/scan",
+            json={"ok": True},
+            request_headers={
+                "Authorization": "Bearer test-antivirus-key",
+            },
+            status_code=200,
+        )
+
+        with app.test_request_context():
+            resp = antivirus.scan(document)
+
+    assert resp
+    assert len(request_mock.request_history) == 1
+    assert "filecontents" in request_mock.request_history[0].text
+    assert request_mock.request_history[0].headers == AnySupersetOf({"some-onwards": "request-header"})
+    assert document.tell() == 0
 
 
-def test_scan_document(antivirus):
+def test_scan_document_no_req_context(app_antivirus):
+    app, antivirus = app_antivirus
     document = io.BytesIO(b"filecontents")
     with requests_mock.Mocker() as request_mock:
         request_mock.post(
@@ -32,11 +64,13 @@ def test_scan_document(antivirus):
         resp = antivirus.scan(document)
 
     assert resp
-    assert "filecontents" in request_mock.last_request.text
+    assert len(request_mock.request_history) == 1
+    assert "filecontents" in request_mock.request_history[0].text
     assert document.tell() == 0
 
 
-def test_should_raise_for_status(antivirus):
+def test_should_raise_for_status(app_antivirus):
+    app, antivirus = app_antivirus
     with pytest.raises(AntivirusError) as excinfo, requests_mock.Mocker() as request_mock:
         request_mock.post("https://antivirus/scan", json={"error": "Antivirus error"}, status_code=400)
 
@@ -46,7 +80,8 @@ def test_should_raise_for_status(antivirus):
     assert excinfo.value.status_code == 400
 
 
-def test_should_raise_for_connection_errors(antivirus):
+def test_should_raise_for_connection_errors(app_antivirus):
+    app, antivirus = app_antivirus
     with pytest.raises(AntivirusError) as excinfo, requests_mock.Mocker() as request_mock:
         request_mock.post("https://antivirus/scan", exc=requests.exceptions.ConnectTimeout)
 


### PR DESCRIPTION
https://trello.com/c/n4FmWuff/585-annotate-logs-with-cloudfront-http-request-ids

A stopgap until we get proper universal tracing support going. At that point it can be removed.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
