### PR TITLE
Set `HOME` in Dockerfile test build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,6 +69,8 @@ RUN usermod -aG sudo notify
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER notify
 
+ENV HOME=/home/vcap
+
 # Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
 RUN mkdir -p app
 


### PR DESCRIPTION
If `HOME` is not set it defaults to `/home/notify` which gives an error when trying to run `make freeze-requirements` of "The directory '/home/notify/.cache/pip' or its parent directory is not owned or is not writable by the current user."



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
