### PR TITLE
Make precommit file match installed black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/psf/black
-  rev: 23.10.1
+  rev: 24.3.0
   hooks:
     - id: black
       name: black (python)


### PR DESCRIPTION
I forgot to do the comment in
https://github.com/alphagov/document-download-api/pull/320/files that says to update pre-commit-config when upgrading our black version



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
