### PR TITLE
remove use of `NOTIFY_RUNTIME_PLATFORM` & `NOTIFY_LOG_PATH` flask config parameters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -30,7 +30,6 @@ class Config:
     MAX_CUSTOM_FILENAME_LENGTH = 100
 
     NOTIFY_APP_NAME = os.environ.get("NOTIFY_APP_NAME")
-    NOTIFY_LOG_PATH = os.environ.get("NOTIFY_LOG_PATH", "application.log")
 
     ANTIVIRUS_API_HOST = os.environ.get("ANTIVIRUS_API_HOST")
     ANTIVIRUS_API_KEY = os.environ.get("ANTIVIRUS_API_KEY")

--- a/app/config.py
+++ b/app/config.py
@@ -32,8 +32,6 @@ class Config:
     NOTIFY_APP_NAME = os.environ.get("NOTIFY_APP_NAME")
     NOTIFY_LOG_PATH = os.environ.get("NOTIFY_LOG_PATH", "application.log")
 
-    NOTIFY_RUNTIME_PLATFORM = os.getenv("NOTIFY_RUNTIME_PLATFORM", "ecs")
-
     ANTIVIRUS_API_HOST = os.environ.get("ANTIVIRUS_API_HOST")
     ANTIVIRUS_API_KEY = os.environ.get("ANTIVIRUS_API_KEY")
 
@@ -68,8 +66,6 @@ class Test(Config):
 
     REDIS_URL = "redis://localhost:6379/1"
 
-    NOTIFY_RUNTIME_PLATFORM = "test"
-
 
 class Development(Config):
     DEBUG = True
@@ -88,8 +84,6 @@ class Development(Config):
     DOCUMENT_DOWNLOAD_API_HOSTNAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOSTNAME", "localhost:7000")
 
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
-
-    NOTIFY_RUNTIME_PLATFORM = "local"
 
 
 class Preview(Config):

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -27,7 +27,7 @@ FILE_TYPES_TO_FORCE_DOWNLOAD_FOR = ["csv", "rtf", "txt"]
 
 @download_blueprint.route("/services/_status")
 def status():
-    response = jsonify({"status": "ok", "platform": current_app.config["NOTIFY_RUNTIME_PLATFORM"]})
+    response = jsonify({"status": "ok"})
     response.headers["Cache-Control"] = "no-store, no-cache, private, must-revalidate"
     return response, 200
 

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
 
 botocore[crt]==1.31.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ markupsafe==2.1.3
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
https://trello.com/c/kuPbusFR/724-check-if-we-should-and-then-remove-notifyruntimeplatform-functionality

~Depends on https://github.com/alphagov/notifications-utils/pull/1109 (though actually doesn't technically require it)~

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
