### PR TITLE
Revert "gunicorn structured logging"

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,11 +1,32 @@
+import os
+import socket
+
+import eventlet
+import gunicorn
 from gds_metrics.gunicorn import child_exit  # noqa
-from notifications_utils.gunicorn_defaults import set_gunicorn_defaults
-
-
-set_gunicorn_defaults(globals())
-
 
 workers = 4
 worker_class = "eventlet"
 worker_connections = 1000
+bind = "0.0.0.0:{}".format(os.getenv("PORT"))
+errorlog = "/home/vcap/logs/gunicorn_error.log"
+gunicorn.SERVER_SOFTWARE = "None"
 keepalive = 90
+
+
+def fix_ssl_monkeypatching():
+    """
+    eventlet works by monkey-patching core IO libraries (such as ssl) to be non-blocking. However, there's currently
+    a bug: In the normal socket library it may throw a timeout error as a `socket.timeout` exception. However
+    eventlet.green.ssl's patch raises an ssl.SSLError('timed out',) instead. redispy handles socket.timeout but not
+    ssl.SSLError, so we solve this by monkey patching the monkey patching code to raise the correct exception type
+    :scream:
+    https://github.com/eventlet/eventlet/issues/692
+    """
+    # this has probably already been called somewhere in gunicorn internals, however, to be sure, we invoke it again.
+    # eventlet.monkey_patch can be called multiple times without issue
+    eventlet.monkey_patch()
+    eventlet.green.ssl.timeout_exc = socket.timeout
+
+
+fix_ssl_monkeypatching()

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.11.0
 
 botocore[crt]==1.31.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,9 +63,7 @@ govuk-bank-holidays==0.14
 greenlet==3.0.3
     # via eventlet
 gunicorn[eventlet]==21.2.0
-    # via
-    #   -r requirements.in
-    #   notifications-utils
+    # via -r requirements.in
 idna==3.6
     # via requests
 itsdangerous==2.1.2
@@ -87,7 +85,7 @@ markupsafe==2.1.3
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.11.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
Reverts alphagov/document-download-api#322

Ugh statsd shouldn't be enabled for this app and the statsd config got included in the common gunicorn configuration