### PR TITLE
Remove environment knowledge from application

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ from gds_metrics import GDSMetrics
 from notifications_utils import logging, request_helper
 from notifications_utils.clients.redis.redis_client import RedisClient
 
-from app.config import configs
+from app.config import Config, configs
 from app.utils.antivirus import AntivirusClient
 from app.utils.store import DocumentStore
 
@@ -24,7 +24,12 @@ mimetypes.init()
 
 def create_app():
     application = Flask("app")
-    application.config.from_object(configs[os.environ["NOTIFY_ENVIRONMENT"]])
+
+    notify_environment = os.environ["NOTIFY_ENVIRONMENT"]
+    if notify_environment in configs:
+        application.config.from_object(configs[notify_environment])
+    else:
+        application.config.from_object(Config)
 
     request_helper.init_app(application)
     logging.init_app(application)

--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,7 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY")
     AUTH_TOKENS = os.environ.get("AUTH_TOKENS")
 
-    DOCUMENTS_BUCKET = None
+    DOCUMENTS_BUCKET = os.getenv("MULTIREGION_ACCESSPOINT_ARN", os.environ.get("DOCUMENTS_BUCKET"))
 
     # map of file extension to MIME TYPE.
     ALLOWED_FILE_TYPES = {
@@ -85,24 +85,7 @@ class Development(Config):
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
 
 
-class Preview(Config):
-    # When running on ECS we set the MULTIREGION_ACCESSPOINT_ARN since we access the bucket
-    # through the multiregion accesspoint
-    DOCUMENTS_BUCKET = os.getenv("MULTIREGION_ACCESSPOINT_ARN", "preview-document-download")
-
-
-class Staging(Config):
-    DOCUMENTS_BUCKET = os.getenv("MULTIREGION_ACCESSPOINT_ARN", "staging-document-download")
-
-
-class Production(Config):
-    DOCUMENTS_BUCKET = os.getenv("MULTIREGION_ACCESSPOINT_ARN", "production-document-download")
-
-
 configs = {
     "test": Test,
     "development": Development,
-    "preview": Preview,
-    "staging": Staging,
-    "production": Production,
 }

--- a/app/performance.py
+++ b/app/performance.py
@@ -11,7 +11,7 @@ def sentry_sampler(sampling_context, sample_rate: float = 0.0):
 
 def init_performance_monitoring():
     environment = os.getenv("NOTIFY_ENVIRONMENT").lower()
-    not_production = environment in {"development", "preview", "staging"}
+    allow_pii = os.getenv("SENTRY_ALLOW_PII", "0") == "1"
     sentry_enabled = bool(int(os.getenv("SENTRY_ENABLED", "0")))
     sentry_dsn = os.getenv("SENTRY_DSN")
 
@@ -21,8 +21,8 @@ def init_performance_monitoring():
         error_sample_rate = float(os.getenv("SENTRY_ERRORS_SAMPLE_RATE", 0.0))
         trace_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", 0.0))
 
-        send_pii = True if not_production else False
-        send_request_bodies = "medium" if not_production else "never"
+        send_pii = True if allow_pii else False
+        send_request_bodies = "medium" if allow_pii else "never"
 
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 


### PR DESCRIPTION
What
----

Remove environment knowledge from application. Environment configuration will be passed in during deployments.

Replace environment name checks with feature flags.

Why
----

We are updating our notify deployment model to allow for many more environments. As such environment settings will be kept in as few places as possible (eventually just one place).

The main benefit of this is to be able to add new environments without having to modify source code

Note
----

This change should not be merged until the deployment configuration has been updated. See [the following pr](https://github.com/alphagov/notifications-aws/pull/2210)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
