### PR TITLE
Match pyup config to admin and API

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -7,9 +7,7 @@ update: insecure
 
 search: False
 requirements:
-  - requirements-app.txt:
-      update: insecure
-  - requirements-dev.txt:
-      update: insecure
-  - requirements.txt:
-      update: False
+  - requirements.in:
+    update: insecure
+  - requirements_for_test.txt:
+    update: insecure


### PR DESCRIPTION
In most of our apps (for example [admin](https://github.com/alphagov/notifications-admin/blob/642c8f34a2045f9227252cef1b7759e6e82c1b73/.pyup.yml) and [api](https://github.com/alphagov/notifications-api/blob/62305c6e00f50ddeb321a2b6bd432407f941b11e/.pyup.yml)) we have PyUp configured to look at `requirements.in` and `requirements_for_test.txt` 

This means we’ll only get warnings about direct dependencies (the ones we specify).

In document-download-api we specify `requirements.txt` as well, meaning we also get warnings about indirect dependencies.

This commit makes document download consistent with the admin and API apps to reduce the amount of noise.

Also worth noting that `requirements-dev.txt` and `requirements-app.txt` no longer exist.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
