### PR TITLE
config: set `NOTIFY_REQUEST_LOG_LEVEL` to `INFO`

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,8 @@ class Config:
     MAX_DECODED_FILE_SIZE = (2 * 1024 * 1024) + 1024  # ~2MiB: Enforced by us - max file size after b64decode
     MAX_CUSTOM_FILENAME_LENGTH = 100
 
+    NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
+
     NOTIFY_APP_NAME = os.environ.get("NOTIFY_APP_NAME")
 
     ANTIVIRUS_API_HOST = os.environ.get("ANTIVIRUS_API_HOST")


### PR DESCRIPTION
So we actually get request logs

Akin to https://github.com/alphagov/notifications-antivirus/pull/162

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
