### PR TITLE
Bump utils to 79.0.0

### DIFF
--- a/app/utils/antivirus.py
+++ b/app/utils/antivirus.py
@@ -30,13 +30,13 @@ class AntivirusClient:
         self.auth_token = app.config["ANTIVIRUS_API_KEY"]
 
     def scan(self, document_stream):
-        headers = {"Authorization": "Bearer {}".format(self.auth_token)}
+        headers = {"Authorization": f"Bearer {self.auth_token}"}
         if has_request_context() and hasattr(request, "get_onwards_request_headers"):
             headers.update(request.get_onwards_request_headers())
 
         try:
             response = requests.post(
-                "{}/scan".format(self.api_host),
+                f"{self.api_host}/scan",
                 headers=headers,
                 files={"document": document_stream},
             )

--- a/app/utils/authentication.py
+++ b/app/utils/authentication.py
@@ -15,7 +15,7 @@ def check_auth():
     if not incoming_token:
         abort(401, "Unauthorized; bearer token must be provided")
     elif not token_is_valid(incoming_token):
-        abort(403, "Forbidden; invalid bearer token provided {}".format(incoming_token))
+        abort(403, f"Forbidden; invalid bearer token provided {incoming_token}")
 
 
 def token_is_valid(incoming_token):

--- a/app/utils/files.py
+++ b/app/utils/files.py
@@ -1,7 +1,4 @@
-from typing import Tuple
-
-
-def split_filename(filename: str, *, dotted: bool) -> Tuple[str, str]:
+def split_filename(filename: str, *, dotted: bool) -> tuple[str, str]:
     *parts, ext = filename.split(".")
     name = ".".join(parts)
     return name, f".{ext}" if dotted else ext

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -79,7 +79,7 @@ class DocumentStore:
             extra_kwargs["Metadata"]["hashed-recipient-email"] = hashed_recipient_email
             current_app.logger.info(
                 "Enabling email confirmation flow for %(service_id)s/%(document_id)s",
-                dict(service_id=service_id, document_id=document_id),
+                {"service_id": service_id, "document_id": document_id},
             )
 
         if retention_period:
@@ -87,7 +87,7 @@ class DocumentStore:
             extra_kwargs["Tagging"] = urlencode(tags)
             current_app.logger.info(
                 "Setting custom retention period for %(service_id)s/%(document_id)s: %(retention_period)s",
-                dict(service_id=service_id, document_id=document_id, retention_period=retention_period),
+                {"service_id": service_id, "document_id": document_id, "retention_period": retention_period},
             )
 
         if filename:

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -193,7 +193,7 @@ class DocumentStore:
         return os.urandom(32)
 
     def get_document_key(self, service_id, document_id):
-        return "{}/{}".format(service_id, document_id)
+        return f"{service_id}/{document_id}"
 
     def authenticate(self, service_id: str, document_id: str, decryption_key: bytes, email_address: str) -> bool:
         """

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -20,7 +20,7 @@ def get_direct_file_url(service_id, document_id, key, mimetype):
 def get_frontend_download_url(service_id, document_id, key):
     scheme = current_app.config["HTTP_SCHEME"]
     netloc = current_app.config["FRONTEND_HOSTNAME"]
-    path = "d/{}/{}".format(uuid_to_base64(service_id), uuid_to_base64(document_id))
+    path = f"d/{uuid_to_base64(service_id)}/{uuid_to_base64(document_id)}"
     query = urlencode({"key": bytes_to_base64(key)})
 
     return urlunsplit([scheme, netloc, path, query, None])

--- a/requirements.in
+++ b/requirements.in
@@ -9,14 +9,8 @@ rsa>=4.3
 
 gunicorn[eventlet]>=21.2.0
 
-awscli-cwlogs>=1.4,<1.5
-
 gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
-
-botocore[crt]==1.31.7
-
-sentry_sdk[flask]>=1.0.0,<2.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,43 +8,28 @@ argon2-cffi==21.3.0
     # via -r requirements.in
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
-awscli==1.29.7
-    # via awscli-cwlogs
-awscli-cwlogs==1.4.6
-    # via -r requirements.in
-awscrt==0.16.26
-    # via botocore
 blinker==1.7.0
     # via
     #   flask
     #   gds-metrics
-    #   sentry-sdk
-boto3==1.28.7
+boto3==1.34.129
     # via notifications-utils
-botocore[crt]==1.31.7
+botocore==1.34.129
     # via
-    #   -r requirements.in
-    #   awscli
     #   boto3
     #   s3transfer
-cachetools==5.3.2
+cachetools==5.3.3
     # via notifications-utils
 certifi==2023.11.17
-    # via
-    #   requests
-    #   sentry-sdk
+    # via requests
 cffi==1.16.0
     # via argon2-cffi-bindings
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via flask
-colorama==0.4.4
-    # via awscli
 dnspython==2.6.1
     # via eventlet
-docutils==0.16
-    # via awscli
 eventlet==0.35.2
     # via gunicorn
 flask==3.0.0
@@ -53,7 +38,6 @@ flask==3.0.0
     #   flask-redis
     #   gds-metrics
     #   notifications-utils
-    #   sentry-sdk
 flask-redis==0.4.0
     # via notifications-utils
 gds-metrics==0.2.4
@@ -83,11 +67,10 @@ jmespath==1.0.1
 markupsafe==2.1.3
     # via
     #   jinja2
-    #   sentry-sdk
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -104,44 +87,29 @@ pycparser==2.21
 pypdf==3.17.4
     # via notifications-utils
 python-dateutil==2.8.2
-    # via
-    #   awscli-cwlogs
-    #   botocore
+    # via botocore
 python-json-logger==2.0.7
     # via notifications-utils
 python-magic==0.4.25
     # via -r requirements.in
-pytz==2023.3.post1
+pytz==2024.1
     # via notifications-utils
 pyyaml==6.0.1
-    # via
-    #   awscli
-    #   notifications-utils
+    # via notifications-utils
 redis==5.0.1
     # via flask-redis
 requests==2.32.0
     # via
-    #   awscli-cwlogs
     #   govuk-bank-holidays
     #   notifications-utils
 rsa==4.7.2
-    # via
-    #   -r requirements.in
-    #   awscli
-s3transfer==0.6.2
-    # via
-    #   awscli
-    #   boto3
+    # via -r requirements.in
+s3transfer==0.10.1
+    # via boto3
 segno==1.6.0
     # via notifications-utils
-sentry-sdk[flask]==1.39.1
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
 six==1.16.0
-    # via
-    #   awscli-cwlogs
-    #   python-dateutil
+    # via python-dateutil
 smartypants==2.0.1
     # via notifications-utils
 statsd==4.0.1
@@ -150,7 +118,6 @@ urllib3==1.26.18
     # via
     #   botocore
     #   requests
-    #   sentry-sdk
 werkzeug==3.0.3
     # via
     #   -r requirements.in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,4 +57,4 @@ class Matcher:
         return self.key(other)
 
     def __repr__(self):
-        return "<Matcher: {}>".format(self.description)
+        return f"<Matcher: {self.description}>"

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -143,7 +143,7 @@ def test_document_key_with_uuid(store):
     service_id = uuid.uuid4()
     document_id = uuid.uuid4()
 
-    assert store.get_document_key(service_id, document_id) == "{}/{}".format(str(service_id), str(document_id))
+    assert store.get_document_key(service_id, document_id) == f"{str(service_id)}/{str(document_id)}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
 ## 79.0.0

* Switches on Pyupgrade and a bunch of other more opinionated linting rules

 ## 78.2.0

* Bumped minimum versions of select subdependencies

 ## 78.1.0

* Restrict postcodes to valid UK postcode zones

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/78.0.0...79.0.0

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
