### PR TITLE
Restore Sentry dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,3 +14,4 @@ gds-metrics==0.2.4
 argon2-cffi==21.3.0
 
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
+sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ blinker==1.7.0
     # via
     #   flask
     #   gds-metrics
+    #   sentry-sdk
 boto3==1.34.129
     # via notifications-utils
 botocore==1.34.129
@@ -21,7 +22,9 @@ botocore==1.34.129
 cachetools==5.3.3
     # via notifications-utils
 certifi==2023.11.17
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
 cffi==1.16.0
     # via argon2-cffi-bindings
 charset-normalizer==3.3.2
@@ -38,6 +41,7 @@ flask==3.0.0
     #   flask-redis
     #   gds-metrics
     #   notifications-utils
+    #   sentry-sdk
 flask-redis==0.4.0
     # via notifications-utils
 gds-metrics==0.2.4
@@ -67,6 +71,7 @@ jmespath==1.0.1
 markupsafe==2.1.3
     # via
     #   jinja2
+    #   sentry-sdk
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
@@ -108,6 +113,8 @@ s3transfer==0.10.1
     # via boto3
 segno==1.6.0
     # via notifications-utils
+sentry-sdk[flask]==1.45.0
+    # via -r requirements.in
 six==1.16.0
     # via python-dateutil
 smartypants==2.0.1
@@ -118,6 +125,7 @@ urllib3==1.26.18
     # via
     #   botocore
     #   requests
+    #   sentry-sdk
 werkzeug==3.0.3
     # via
     #   -r requirements.in


### PR DESCRIPTION
It was removed by mistake:
https://github.com/alphagov/document-download-api/pull/340/commits/25262ea9a180af3cf61bb332598dbf917cd24ae4#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552L137



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
