### PR TITLE
Bump notifications-utils plus add environment config variable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,10 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY")
     AUTH_TOKENS = os.environ.get("AUTH_TOKENS")
 
+    # The config option NOTIFY_ENVIRONMENT is purely used for logging.
+    # It should not be used for any logical conditionals in the code.
+    NOTIFY_ENVIRONMENT = os.environ["NOTIFY_ENVIRONMENT"]
+
     DOCUMENTS_BUCKET = os.getenv("MULTIREGION_ACCESSPOINT_ARN", os.environ.get("DOCUMENTS_BUCKET"))
 
     # map of file extension to MIME TYPE.

--- a/requirements.in
+++ b/requirements.in
@@ -8,5 +8,6 @@ gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@80.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.1.1
+
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ markupsafe==2.1.3
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@80.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.1.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
What
----

- Include notify-environment for logging.
- Bump notifications-utils

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
