### PR TITLE
Add a note about how to bump utils version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ gds-metrics==0.2.4
 
 argon2-cffi==21.3.0
 
+# Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.1.1
 
 sentry_sdk[flask]>=1.0.0,<2.0.0


### PR DESCRIPTION
You wouldn’t know about this without looking in the `Makefile`, and it’s easier to use the command than do it manually.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
