### PR TITLE
application: use `EventletTimeoutMiddleware` if using eventlet

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,4 +1,5 @@
 ##!/usr/bin/env python
+import os
 
 from app.performance import init_performance_monitoring
 
@@ -6,4 +7,12 @@ init_performance_monitoring()
 
 from app import create_app  # noqa
 
+from notifications_utils.eventlet import EventletTimeoutMiddleware, using_eventlet  # noqa
+
 application = create_app()
+
+if using_eventlet:
+    application.wsgi_app = EventletTimeoutMiddleware(
+        application.wsgi_app,
+        timeout_seconds=int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30)),
+    )

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,6 +1,7 @@
+import os
+
 from gds_metrics.gunicorn import child_exit  # noqa
 from notifications_utils.gunicorn_defaults import set_gunicorn_defaults
-
 
 set_gunicorn_defaults(globals())
 
@@ -9,3 +10,4 @@ workers = 4
 worker_class = "eventlet"
 worker_connections = 1000
 keepalive = 90
+timeout = int(os.getenv("HTTP_SERVE_TIMEOUT_SECONDS", 30))  # though has little effect with eventlet worker_class


### PR DESCRIPTION
Also catch `EventletTimeout` exceptions, turning these into 504s, which are the closest thing to an application timeout standard codes seem to cover.

30s timeout as this is what we've decided to set our cloudfront/ALB timeouts to (we'll make this change shortly).

In `EventletTimeoutMiddleware`'s current implementation, the timeout gets cancelled as soon as the initial status response is returned, so streaming responses shouldn't be affected any more than normal responses.

p.s. where are the rest of our error handlers for this app?

Passes dev-a @ https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/59

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
