### PR TITLE
notifications-utils: 87.1.0 -> 88.0.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ gds-metrics==0.2.4
 argon2-cffi==21.3.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@87.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@88.0.1
 
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ markupsafe==2.1.3
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@87.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@88.0.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
Incorporating https://github.com/alphagov/notifications-utils/pull/1161

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
