### PR TITLE
Dockerfile: set UV_COMPILE_BYTECODE=1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim-bookworm AS base
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    UV_COMPILE_BYTECODE=1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
> By default, uv does not compile Python (.py) files
> to bytecode (__pycache__/*.pyc); instead, compilation
> is performed lazily the first time a module is imported.
> For use-cases in which start time is critical, such as
> CLI applications and Docker containers, this option can
> be enabled to trade longer installation times for faster
> start times.

Without this we will see increased startup times for apps which can in turn break the dev envs, where instances have reduced cpu and can’t compile all their bytecode in time to return a healthcheck.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
