### PR TITLE
Bump utils to 92.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@89.2.0
+# This file was automatically copied from notifications-utils@92.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -9,12 +9,12 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.3.7'
+  rev: 'v0.8.2'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/psf/black
-  rev: 24.4.0
+  rev: 24.10.0
   hooks:
     - id: black
       name: black (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@89.2.0
+# This file was automatically copied from notifications-utils@92.0.1
 
 [tool.black]
 line-length = 120
@@ -22,6 +22,7 @@ lint.select = [
     "ISC",  # flake8-implicit-str-concat
     "RSE",  # flake8-raise
     "PIE",  # flake8-pie
+    "N804",  # First argument of a class method should be named `cls`
 ]
 lint.ignore = []
 exclude = [

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ gds-metrics==0.2.4
 argon2-cffi==21.3.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@89.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.1
 
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 awscrt==0.20.11
     # via botocore
-blinker==1.7.0
+blinker==1.9.0
     # via
     #   flask
     #   gds-metrics
@@ -17,7 +17,7 @@ botocore==1.34.129
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.3
+cachetools==5.5.0
     # via notifications-utils
 certifi==2024.7.4
     # via
@@ -33,7 +33,7 @@ dnspython==2.6.1
     # via eventlet
 eventlet==0.35.2
     # via gunicorn
-flask==3.0.0
+flask==3.1.0
     # via
     #   flask-redis
     #   gds-metrics
@@ -43,7 +43,7 @@ flask-redis==0.4.0
     # via notifications-utils
 gds-metrics==0.2.4
     # via -r requirements.in
-govuk-bank-holidays==0.14
+govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
     # via eventlet
@@ -51,7 +51,7 @@ gunicorn==21.2.0
     # via notifications-utils
 idna==3.7
     # via requests
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   flask
     #   notifications-utils
@@ -70,13 +70,13 @@ markupsafe==2.1.3
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@4741402d194bb0dfc87d15b2dae16dd193cb5591
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
 packaging==23.2
     # via gunicorn
-phonenumbers==8.13.49
+phonenumbers==8.13.52
     # via notifications-utils
 prometheus-client==0.19.0
     # via gds-metrics
@@ -92,13 +92,13 @@ python-json-logger==2.0.7
     # via notifications-utils
 python-magic==0.4.25
     # via -r requirements.in
-pytz==2024.1
+pytz==2024.2
     # via notifications-utils
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via notifications-utils
 redis==5.0.1
     # via flask-redis
-requests==2.32.0
+requests==2.32.3
     # via
     #   govuk-bank-holidays
     #   notifications-utils
@@ -106,7 +106,7 @@ rsa==4.7.2
     # via -r requirements.in
 s3transfer==0.10.1
     # via boto3
-segno==1.6.0
+segno==1.6.1
     # via notifications-utils
 sentry-sdk==1.45.0
     # via -r requirements.in
@@ -121,5 +121,5 @@ urllib3==1.26.19
     #   botocore
     #   requests
     #   sentry-sdk
-werkzeug==3.0.6
+werkzeug==3.1.3
     # via flask

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -7,18 +7,16 @@ argon2-cffi-bindings==21.2.0
     #   -r requirements.txt
     #   argon2-cffi
 attrs==24.2.0
-    # via
-    #   hypothesis
-    #   pytest
+    # via hypothesis
 awscrt==0.20.11
     # via
     #   -r requirements.txt
     #   botocore
-beautifulsoup4==4.11.1
+beautifulsoup4==4.12.3
     # via -r requirements_for_test_common.in
-black==24.4.0
+black==24.10.0
     # via -r requirements_for_test_common.in
-blinker==1.7.0
+blinker==1.9.0
     # via
     #   -r requirements.txt
     #   flask
@@ -32,7 +30,7 @@ botocore==1.34.129
     #   -r requirements.txt
     #   boto3
     #   s3transfer
-cachetools==5.3.3
+cachetools==5.5.0
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -54,23 +52,19 @@ click==8.1.7
     #   -r requirements.txt
     #   black
     #   flask
-colorama==0.4.6
-    # via pytest-watch
 coverage==7.6.4
     # via pytest-testmon
 dnspython==2.6.1
     # via
     #   -r requirements.txt
     #   eventlet
-docopt==0.6.2
-    # via pytest-watch
 eventlet==0.35.2
     # via
     #   -r requirements.txt
     #   gunicorn
 execnet==2.1.1
     # via pytest-xdist
-flask==3.0.0
+flask==3.1.0
     # via
     #   -r requirements.txt
     #   flask-redis
@@ -80,11 +74,11 @@ flask-redis==0.4.0
     # via
     #   -r requirements.txt
     #   notifications-utils
-freezegun==1.2.2
+freezegun==1.5.1
     # via -r requirements_for_test_common.in
 gds-metrics==0.2.4
     # via -r requirements.txt
-govuk-bank-holidays==0.14
+govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -104,7 +98,7 @@ idna==3.7
     #   requests
 iniconfig==2.0.0
     # via pytest
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   -r requirements.txt
     #   flask
@@ -130,7 +124,7 @@ mistune==0.8.4
     #   notifications-utils
 mypy-extensions==1.0.0
     # via black
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@4741402d194bb0dfc87d15b2dae16dd193cb5591
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
     # via -r requirements.txt
 ordered-set==4.1.0
     # via
@@ -144,7 +138,7 @@ packaging==23.2
     #   pytest
 pathspec==0.12.1
     # via black
-phonenumbers==8.13.49
+phonenumbers==8.13.52
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -168,23 +162,20 @@ pypdf==3.17.4
     # via
     #   -r requirements.txt
     #   notifications-utils
-pytest==7.2.0
+pytest==8.3.4
     # via
     #   -r requirements_for_test_common.in
     #   pytest-env
     #   pytest-mock
     #   pytest-testmon
-    #   pytest-watch
     #   pytest-xdist
-pytest-env==0.8.1
+pytest-env==1.1.5
     # via -r requirements_for_test_common.in
-pytest-mock==3.9.0
+pytest-mock==3.14.0
     # via -r requirements_for_test_common.in
-pytest-testmon==2.1.0
+pytest-testmon==2.1.1
     # via -r requirements_for_test_common.in
-pytest-watch==4.2.0
-    # via -r requirements_for_test_common.in
-pytest-xdist==3.0.2
+pytest-xdist==3.6.1
     # via -r requirements_for_test_common.in
 python-dateutil==2.8.2
     # via
@@ -197,11 +188,11 @@ python-json-logger==2.0.7
     #   notifications-utils
 python-magic==0.4.25
     # via -r requirements.txt
-pytz==2024.1
+pytz==2024.2
     # via
     #   -r requirements.txt
     #   notifications-utils
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -209,23 +200,23 @@ redis==5.0.1
     # via
     #   -r requirements.txt
     #   flask-redis
-requests==2.32.0
+requests==2.32.3
     # via
     #   -r requirements.txt
     #   govuk-bank-holidays
     #   notifications-utils
     #   requests-mock
-requests-mock==1.10.0
+requests-mock==1.12.1
     # via -r requirements_for_test_common.in
 rsa==4.7.2
     # via -r requirements.txt
-ruff==0.3.7
+ruff==0.8.2
     # via -r requirements_for_test_common.in
 s3transfer==0.10.1
     # via
     #   -r requirements.txt
     #   boto3
-segno==1.6.0
+segno==1.6.1
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -235,7 +226,6 @@ six==1.16.0
     # via
     #   -r requirements.txt
     #   python-dateutil
-    #   requests-mock
 smartypants==2.0.1
     # via
     #   -r requirements.txt
@@ -254,9 +244,7 @@ urllib3==1.26.19
     #   botocore
     #   requests
     #   sentry-sdk
-watchdog==6.0.0
-    # via pytest-watch
-werkzeug==3.0.6
+werkzeug==3.1.3
     # via
     #   -r requirements.txt
     #   flask

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,14 +1,13 @@
-# This file was automatically copied from notifications-utils@89.2.0
+# This file was automatically copied from notifications-utils@92.0.1
 
-beautifulsoup4==4.11.1
-pytest==7.2.0
-pytest-env==0.8.1
-pytest-mock==3.9.0
-pytest-xdist==3.0.2
-pytest-testmon==2.1.0
-pytest-watch==4.2.0
-requests-mock==1.10.0
-freezegun==1.2.2
+beautifulsoup4==4.12.3
+pytest==8.3.4
+pytest-env==1.1.5
+pytest-mock==3.14.0
+pytest-xdist==3.6.1
+pytest-testmon==2.1.1
+requests-mock==1.12.1
+freezegun==1.5.1
 
-black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
-ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes
+black==24.10.0  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.8.2  # Also update `.pre-commit-config.yaml` if this changes


### PR DESCRIPTION
 ## 92.0.1

* Bumps core dependencies to latest versions

 ## 92.0.0

* Restores old validation code so later utils changes can be added to api, admin etc.

 ## 91.1.2

* Adds rule N804 (invalid-first-argument-name-for-class-method) to linter config

 ## 91.1.1

* Remove hangul filler character from rendered emails

 ## 91.1.0

* bump all libs in requirements_for_test_common.in

 ## 91.0.4

* Don’t copy config when bumping utils version

 ## 91.0.3

* Fix validating supported international country codes for phone numbers without a leading "+" that look a bit like UK numbers

 ## 91.0.2

* Bumps requests to newer version

 ## 91.0.1

* Adds public utility method to check if a phonenumber is international (with correct handling for OFCOM TV numbers)
* Updates PhoneNumber.get_international_phone_info to return the correct info for OFCOM TV numbers

 ## 91.0.0

* BREAKING CHANGE: All standalone functions for validating, normalising and formatting phone numbers has been removed from notifications_utils/recipient_validation/phone_number.py, and are replaced and encapsualated entirely with a single `PhoneNumber` class. All code that relies on validation, normalisation or fomratting of a phone number must be re-written to use instances of `PhoneNumber` instead.

 ## 90.0.0

* Allow leading empty columns in CSV files
* Change second argument of `formatters.strip_all_whitespace` (this argument is not used in other apps)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/89.2.0...92.0.1



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
