### PR TITLE
Bump utils to 92.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@92.1.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@92.1.1
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ gds-metrics==0.2.4
 argon2-cffi==21.3.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.1.1
 
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ itsdangerous==2.2.0
     # via
     #   flask
     #   notifications-utils
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   flask
     #   notifications-utils
@@ -70,7 +70,7 @@ markupsafe==2.1.3
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b9ef1b45b655324d6341995afffc3ebc25a3ed72
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -103,7 +103,7 @@ itsdangerous==2.2.0
     #   -r requirements.txt
     #   flask
     #   notifications-utils
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r requirements.txt
     #   flask
@@ -124,7 +124,7 @@ mistune==0.8.4
     #   notifications-utils
 mypy-extensions==1.0.0
     # via black
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b9ef1b45b655324d6341995afffc3ebc25a3ed72
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@92.1.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4


### PR DESCRIPTION
 ## 92.1.1

* Bump minimum version of `jinja2` to 3.1.5

 ## 92.1.0

* RequestCache: add CacheResultWrapper to allow dynamic cache decisions

 ## 92.0.2

* Downgrade minimum version of `requests` to 2.32.3

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/92.0.1...92.1.1


---

Fixes #363

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
