### PR TITLE
Bump gunicorn to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ click==8.1.7
     # via flask
 dnspython==2.6.1
     # via eventlet
-eventlet==0.35.2
+eventlet==0.39.1
     # via gunicorn
 flask==3.1.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
     # via eventlet
-gunicorn==21.2.0
+gunicorn==23.0.0
     # via notifications-utils
 idna==3.7
     # via requests

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -55,7 +55,7 @@ dnspython==2.6.1
     # via
     #   -r requirements.txt
     #   eventlet
-eventlet==0.35.2
+eventlet==0.39.1
     # via
     #   -r requirements.txt
     #   gunicorn

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -83,7 +83,7 @@ greenlet==3.0.3
     # via
     #   -r requirements.txt
     #   eventlet
-gunicorn==21.2.0
+gunicorn==23.0.0
     # via
     #   -r requirements.txt
     #   notifications-utils


### PR DESCRIPTION
The version of Gunicorn we are using is more than 18 months out of date<sup>1</sup> and has a high severity security vulnerability<sup>2</sup>.

We have not updated the version on the API (and therefore the minimum version in utils<sup>3</sup>) because last time we tried (while still on PaaS) it had some performance issues, documented here<sup>4</sup>:

> We originally pinned this due to eventlet v0.33 compatibility issues. That was supposedly fixed in version v21.0.0 and we merged v21.2.0 for a while. Until we ran a load test again, and identified that the bumped version of gunicorn led to a 33%+ drop-off in performance/requests per second that the API was able to handle. If a version greater than 21.2.0 is released, and it either gives us something we need or we think it addresses said performance issues, make sure to run a load test in staging before releasing to production.

But document download does not serve anywhere near the same number of requests per second as the API, so we have already upgraded to version 21.2.0.

This pull request just updates from 21.2.0 to 23.0.0 (the latest version), which resolves the security vulnerability.

***

1. https://github.com/benoitc/gunicorn/tree/21.2.0
2. https://github.com/advisories/GHSA-w3h3-4rj7-4ph4
3. https://github.com/alphagov/notifications-utils/blob/main/setup.py#L31
4. https://github.com/alphagov/notifications-api/blob/aff08653d951d6f60dec8d701ae7cf1681b78a27/requirements.in#L10

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
