### PR TITLE
Install uv from Docker registry

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,12 @@
 FROM python:3.11-slim-bookworm AS base
 
+COPY --from=ghcr.io/astral-sh/uv:0.5.30 /uv /uvx /bin/
+
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
-    UV_COMPILE_BYTECODE=1
+    UV_COMPILE_BYTECODE=1 \
+    UV_CACHE_DIR='/tmp/uv-cache/' \
+    VIRTUAL_ENV="/opt/venv"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -29,9 +33,6 @@ RUN echo "Install OS dependencies for python app requirements" &&  \
 
 COPY requirements.txt ./
 
-RUN pip install uv
-
-ENV UV_CACHE_DIR='/tmp/uv-cache/'
 RUN echo "Installing python dependencies" && \
     python3 -m venv /opt/venv && \
     uv pip sync --python /opt/venv/bin/python requirements.txt
@@ -88,9 +89,7 @@ RUN mkdir -p app
 COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 
 # Install dev/test requirements
-RUN pip install uv
 COPY --chown=notify:notify Makefile requirements_for_test.txt ./
-ENV UV_CACHE_DIR='/tmp/uv-cache/'
 RUN make bootstrap
 
 # Copy from the real world, one dir up (project root) into the environment's current working directory


### PR DESCRIPTION
Copies https://github.com/alphagov/notifications-api/pull/4376

Ensures we don’t get bitten by breaking changes to uv.

Also consolidates environment variables into a single block.