### PR TITLE
Bump Sentry SDK to 1.45.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,4 +11,4 @@ argon2-cffi==21.3.0
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@95.1.1
 
-sentry_sdk[flask]>=1.0.0,<2.0.0
+sentry-sdk[flask]==1.45.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,7 +108,7 @@ s3transfer==0.10.1
     # via boto3
 segno==1.6.1
     # via notifications-utils
-sentry-sdk==1.45.0
+sentry-sdk==1.45.1
     # via -r requirements.in
 six==1.16.0
     # via python-dateutil

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -210,7 +210,7 @@ segno==1.6.1
     # via
     #   -r requirements.txt
     #   notifications-utils
-sentry-sdk==1.45.0
+sentry-sdk==1.45.1
     # via -r requirements.txt
 six==1.16.0
     # via


### PR DESCRIPTION
Fixes GHSA-g92j-qhmh-64v2

Not something that likely affects us, but clears down another Dependabot warning.

This fix was released in sentry-sdk==2.8.0, then also backported to sentry-sdk==1.45.1.

I think we could probably upgrade to Sentry >= 2 without making any changes, but more testing would be needed to validate this. So just going with the backport for now.

Specifying an exact version because that’s our convention.