### PR TITLE
Bump utils to 97.0.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.1
+# This file was automatically copied from notifications-utils@97.0.3
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,7 +1,7 @@
 import os
 
 from gds_metrics.gunicorn import child_exit  # noqa
-from notifications_utils.gunicorn_defaults import set_gunicorn_defaults
+from notifications_utils.gunicorn.defaults import set_gunicorn_defaults
 
 set_gunicorn_defaults(globals())
 

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ gds-metrics==0.2.4
 argon2-cffi==21.3.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@95.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.3
 
 sentry-sdk[flask]==1.45.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ itsdangerous==2.2.0
     # via
     #   flask
     #   notifications-utils
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   flask
     #   notifications-utils
@@ -70,7 +70,7 @@ markupsafe==2.1.3
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@361486ff4960b5d02c162118b1fd64b097f9cb96
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3fb3caf0efc9ccbebfe79b3269f84bfd66fc90d5
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -100,7 +100,7 @@ itsdangerous==2.2.0
     #   -r requirements.txt
     #   flask
     #   notifications-utils
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements.txt
     #   flask
@@ -119,7 +119,7 @@ mistune==0.8.4
     # via
     #   -r requirements.txt
     #   notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@361486ff4960b5d02c162118b1fd64b097f9cb96
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3fb3caf0efc9ccbebfe79b3269f84bfd66fc90d5
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.1
+# This file was automatically copied from notifications-utils@97.0.3
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.1
+# This file was automatically copied from notifications-utils@97.0.3
 
 exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 97.0.3

* Bump minimum jinja2 version to 3.1.6 (closes #372)

 ## 97.0.2

* Fix external link redirect

 ## 97.0.1

* Fix QR code URL with '&' encoded as '&amp;'

 ## 97.0.0

* for bilingual letters preview, only show barcodes on the first page (patch).
* rename `include_notify_tag` argument to `includes_first_page` (major).

 ## 96.0.0

* BREAKING CHANGE: the `gunicorn_defaults` module has been moved to `gunicorn.defaults` to make space for gunicorn-related utils that don't have the restricted-import constraints of the gunicorn defaults. Imports of `notifications_utils.gunicorn_defaults` should be changed to `notifications_utils.gunicorn.defaults`.
* Added `ContextRecyclingEventletWorker` custom gunicorn worker class.

 ## 95.2.0

* Implement `InsensitiveSet.__contains__`

 ## 95.1.2

* Fix to the number of arguments the `on_retry` of the `NotifyTask` class takes.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/95.1.1...97.0.3