### PR TITLE
Rework error handling

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -77,7 +77,7 @@ def download_document(service_id, document_id, extension=None):
                 "document_id": document_id,
             },
         )
-        return jsonify(error=str(e)), 400
+        return jsonify(error=str(e)), e.suggested_status_code
 
     if redirect := get_redirect_url_if_user_not_authenticated(request, document):
         return redirect
@@ -130,24 +130,21 @@ def get_document_metadata(service_id, document_id):
                 "document_id": document_id,
             },
         )
-        return jsonify(error=str(e)), 400
+        return jsonify(error=str(e)), e.suggested_status_code
 
-    if metadata:
-        document = {
-            "direct_file_url": get_direct_file_url(
-                service_id=service_id,
-                document_id=document_id,
-                key=key,
-                mimetype=metadata["mimetype"],
-            ),
-            "confirm_email": metadata["confirm_email"],
-            "size_in_bytes": metadata["size"],
-            "file_extension": current_app.config["MIME_TYPES_TO_FILE_EXTENSIONS"][metadata["mimetype"]],
-            "filename": metadata["filename"],
-            "available_until": metadata["available_until"],
-        }
-    else:
-        document = None
+    document = {
+        "direct_file_url": get_direct_file_url(
+            service_id=service_id,
+            document_id=document_id,
+            key=key,
+            mimetype=metadata["mimetype"],
+        ),
+        "confirm_email": metadata["confirm_email"],
+        "size_in_bytes": metadata["size"],
+        "file_extension": current_app.config["MIME_TYPES_TO_FILE_EXTENSIONS"][metadata["mimetype"]],
+        "filename": metadata["filename"],
+        "available_until": metadata["available_until"],
+    }
 
     response = make_response({"document": document})
     response.headers["X-Robots-Tag"] = "noindex, nofollow"

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -168,13 +168,13 @@ class DocumentStore:
                 SSECustomerAlgorithm="AES256",
             )
 
-            expiry_date = self._convert_expiry_date_to_date_object(metadata["Expiration"])
-
             return {
                 "mimetype": metadata["ContentType"],
                 "confirm_email": self.get_email_hash(metadata) is not None,
                 "size": metadata["ContentLength"],
-                "available_until": str(expiry_date),
+                "available_until": str(self._convert_expiry_date_to_date_object(metadata["Expiration"]))
+                if metadata.get("Expiration")
+                else None,
                 "filename": self._normalise_metadata(metadata["Metadata"]).get("filename"),
             }
         except BotoClientError as e:

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -5,6 +5,7 @@ from unittest import mock
 import botocore
 import pytest
 from botocore.exceptions import ClientError as BotoClientError
+from freezegun import freeze_time
 
 from app.utils.store import (
     DocumentBlocked,
@@ -26,6 +27,7 @@ def mock_boto(mocker):
 def store(mock_boto):
     mock_boto.client.return_value.get_object.return_value = {
         "Body": mock.Mock(),
+        "Expiration": 'expiry-date="Fri, 01 May 2020 00:00:00 GMT", expiry-rule="custom-retention-1-weeks"',
         "ContentType": "application/pdf",
         "ContentLength": 100,
         "Metadata": {},
@@ -53,7 +55,7 @@ def blocked_document(mock_boto):
 
 
 @pytest.fixture
-def expired_document(mock_boto):
+def delete_markered_document(mock_boto):
     mock_boto.client.return_value.get_object_tagging.side_effect = botocore.exceptions.ClientError(
         {
             "Error": {
@@ -156,7 +158,7 @@ def test_check_for_blocked_document_raises_error(store, mock_boto, blocked_value
         store.check_for_blocked_document("service-id", "doc-id")
 
 
-def test_check_for_blocked_document_raises_expired_error(store, expired_document):
+def test_check_for_blocked_document_delete_marker_document_expired_error(store, delete_markered_document):
     with pytest.raises(DocumentExpired):
         store.check_for_blocked_document("service-id", "doc-id")
 
@@ -189,6 +191,42 @@ def test_check_for_blocked_document_random_error_propagated(store):
 
     with pytest.raises(BotoClientError):
         store.check_for_blocked_document("service-id", "doc-id")
+
+
+@pytest.mark.parametrize(
+    "expiration",
+    (
+        'expiry-date="Fri, 01 May 2020 00:00:00 GMT", expiry-rule="custom-retention-1-weeks"',
+        'expiry-date="Sat, 02 May 2020 00:00:00 GMT", expiry-rule="custom-retention-3-weeks"',
+    ),
+)
+def test_check_for_expired_document_expired(store, expiration):
+    with freeze_time("2020-05-02 10:00:00"):
+        with pytest.raises(DocumentExpired):
+            store.check_for_expired_document(
+                {
+                    "Expiration": expiration,
+                }
+            )
+
+
+@pytest.mark.parametrize(
+    "expiration",
+    (
+        'expiry-date="Sun, 03 May 2020 00:00:00 GMT", expiry-rule="custom-retention-1-weeks"',
+        None,
+    ),
+)
+def test_check_for_expired_document_not_expired(store, expiration):
+    with freeze_time("2020-05-02 10:00:00"):
+        assert (
+            store.check_for_expired_document(
+                {
+                    "Expiration": expiration,
+                }
+            )
+            is None
+        )
 
 
 def test_put_document(store):
@@ -281,12 +319,13 @@ def test_put_document_records_filename_if_set(store, filename, expected_filename
 
 
 def test_get_document(store):
-    assert store.get("service-id", "document-id", bytes(32)) == {
-        "body": mock.ANY,
-        "mimetype": "application/pdf",
-        "size": 100,
-        "metadata": {},
-    }
+    with freeze_time("2020-04-28 10:00:00"):
+        assert store.get("service-id", "document-id", bytes(32)) == {
+            "body": mock.ANY,
+            "mimetype": "application/pdf",
+            "size": 100,
+            "metadata": {},
+        }
 
     store.s3.get_object.assert_called_once_with(
         Bucket="test-bucket",
@@ -311,13 +350,15 @@ def test_get_blocked_document(store, blocked_document):
         store.get("service-id", "document-id", bytes(32))
 
 
-def test_get_expired_document(store, expired_document):
+def test_get_delete_markered_document(store, delete_markered_document):
     with pytest.raises(DocumentExpired):
         store.get("service-id", "document-id", bytes(32))
 
 
 def test_get_document_metadata_when_document_is_in_s3(store):
-    metadata = store.get_document_metadata("service-id", "document-id", "0f0f0f")
+    with freeze_time("2020-04-28 10:00:00"):
+        metadata = store.get_document_metadata("service-id", "document-id", "0f0f0f")
+
     assert metadata == {
         "mimetype": "text/plain",
         "confirm_email": False,
@@ -340,7 +381,9 @@ def test_get_document_metadata_when_document_is_in_s3_but_missing_expiration(sto
 
 
 def test_get_document_metadata_when_document_is_in_s3_with_hashed_email(store_with_email):
-    metadata = store_with_email.get_document_metadata("service-id", "document-id", "0f0f0f")
+    with freeze_time("2020-04-28 10:00:00"):
+        metadata = store_with_email.get_document_metadata("service-id", "document-id", "0f0f0f")
+
     assert metadata == {
         "mimetype": "text/plain",
         "confirm_email": True,
@@ -351,7 +394,9 @@ def test_get_document_metadata_when_document_is_in_s3_with_hashed_email(store_wi
 
 
 def test_get_document_metadata_when_document_is_in_s3_with_filename(store_with_filename):
-    metadata = store_with_filename.get_document_metadata("service-id", "document-id", "0f0f0f")
+    with freeze_time("2020-04-28 10:00:00"):
+        metadata = store_with_filename.get_document_metadata("service-id", "document-id", "0f0f0f")
+
     assert metadata == {
         "mimetype": "text/plain",
         "confirm_email": False,
@@ -359,6 +404,12 @@ def test_get_document_metadata_when_document_is_in_s3_with_filename(store_with_f
         "available_until": "2020-04-30",
         "filename": "✅.pdf",
     }
+
+
+def test_get_document_metadata_when_document_is_in_s3_but_expired(store):
+    with pytest.raises(DocumentExpired):
+        with freeze_time("2020-05-12 10:00:00"):
+            store.get_document_metadata("service-id", "document-id", "0f0f0f")
 
 
 def test_get_document_metadata_when_document_is_not_in_s3(store):
@@ -384,7 +435,7 @@ def test_get_document_metadata_with_blocked_document(store_with_email, blocked_d
         store_with_email.get_document_metadata("service-id", "document-id", "0f0f0f")
 
 
-def test_get_document_metadata_with_expired_document(store_with_email, expired_document):
+def test_get_document_metadata_with_delete_markered_document(store_with_email, delete_markered_document):
     with pytest.raises(DocumentExpired):
         store_with_email.get_document_metadata("service-id", "document-id", "0f0f0f")
 
@@ -414,7 +465,13 @@ def test_authenticate_document_when_missing(store):
     ),
 )
 def test_authenticate_document_email_address_check(store_with_email, email_address, expected_result):
-    assert store_with_email.authenticate("service-id", "document-id", b"0f0f0f", email_address) is expected_result
+    with freeze_time("2020-04-28 10:00:00"):
+        assert store_with_email.authenticate("service-id", "document-id", b"0f0f0f", email_address) is expected_result
+
+
+def test_authenticate_document_expired(store_with_email):
+    with freeze_time("2020-05-28 10:00:00"):
+        assert store_with_email.authenticate("service-id", "document-id", b"0f0f0f", "test@notify.example") is False
 
 
 def test_authenticate_fails_if_document_does_not_have_hash(store):
@@ -439,7 +496,7 @@ def test_authenticate_with_blocked_document(store, blocked_document):
     assert store.authenticate("service-id", "document-id", b"0f0f0f", "test@notify.example") is False
 
 
-def test_authenticate_with_expired_document(store, expired_document):
+def test_authenticate_with_delete_markered_document(store, delete_markered_document):
     assert store.authenticate("service-id", "document-id", b"0f0f0f", "test@notify.example") is False
 
 

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -327,6 +327,18 @@ def test_get_document_metadata_when_document_is_in_s3(store):
     }
 
 
+def test_get_document_metadata_when_document_is_in_s3_but_missing_expiration(store):
+    del store.s3.head_object.return_value["Expiration"]
+    metadata = store.get_document_metadata("service-id", "document-id", "0f0f0f")
+    assert metadata == {
+        "mimetype": "text/plain",
+        "confirm_email": False,
+        "size": 100,
+        "available_until": None,
+        "filename": None,
+    }
+
+
 def test_get_document_metadata_when_document_is_in_s3_with_hashed_email(store_with_email):
     metadata = store_with_email.get_document_metadata("service-id", "document-id", "0f0f0f")
     assert metadata == {


### PR DESCRIPTION
Best reviewed commit-by-commit.

This gets document-download-api acting more-or-less sensibly when encountering missing documents and or documents that are supposed to be expired.

Will require some frontend changes to adapt to the endpoints returning anything other than 400 for these cases.

The app-logic `Expiration` handling is a straight port of the logic that the frontend currently implements, though it could stand to be a lot stronger, potentially directly interpreting the `retention-period` tags directly and comparing them against a tag-stored last-modified timestamp (which doesn't exist yet). Doing this would reduce our 100% dependence on the correct operation of the lifecycle rules and the s3 native last-modified timestamp (which isn't guaranteed to always be there if we e.g. use s3 backup)