### PR TITLE
chore: bump utils to 100.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.1
+# This file was automatically copied from notifications-utils@100.2.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ gds-metrics==0.2.4
 argon2-cffi==21.3.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@100.2.0
 
 sentry-sdk[flask]==1.45.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,13 +71,13 @@ markupsafe==2.1.3
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bb31f41dd194802ced5ea814f84cc25855467234
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
 packaging==23.2
     # via gunicorn
-phonenumbers==8.13.52
+phonenumbers==9.0.10
     # via notifications-utils
 prometheus-client==0.19.0
     # via gds-metrics
@@ -87,8 +87,10 @@ pycparser==2.21
     # via cffi
 pypdf==3.17.4
     # via notifications-utils
-python-dateutil==2.8.2
-    # via botocore
+python-dateutil==2.9.0.post0
+    # via
+    #   botocore
+    #   notifications-utils
 python-json-logger==3.3.0
     # via notifications-utils
 python-magic==0.4.25

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -120,7 +120,7 @@ mistune==0.8.4
     # via
     #   -r requirements.txt
     #   notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bb31f41dd194802ced5ea814f84cc25855467234
     # via -r requirements.txt
 ordered-set==4.1.0
     # via
@@ -131,7 +131,7 @@ packaging==23.2
     #   -r requirements.txt
     #   gunicorn
     #   pytest
-phonenumbers==8.13.52
+phonenumbers==9.0.10
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -168,11 +168,12 @@ pytest-testmon==2.1.1
     # via -r requirements_for_test_common.in
 pytest-xdist==3.6.1
     # via -r requirements_for_test_common.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
     #   botocore
     #   freezegun
+    #   notifications-utils
 python-json-logger==3.3.0
     # via
     #   -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.1
+# This file was automatically copied from notifications-utils@100.2.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.5.1
+# This file was automatically copied from notifications-utils@100.2.0
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
Bump utils to 100.2.0

 ## 100.2.0

* add  fields to pre/post request flask logs

 ## 100.1.0

* Updated  to version 9.0.9 to keep phonenumber metadata uptodate

 ## 100.0.0

*  is now a required argument of  (apps have already been updated)

 ## 99.8.0

* Add new version of GOV.UK brand to email template, behind a flag

 ## 99.7.0

* Update economy letter transit dates to max 8 days

 ## 99.6.0

* Improve celery json logging. Include beat with separate log level options and testing

 ## 99.5.2

* Make inheritence of annotations on SerialisedModel work on both the class and its instances

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/99.5.1...100.2.0