### PR TITLE
Remove unused `rsa` dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,6 @@
 # with package version changes made in requirements.in
 
 python-magic~=0.4
-rsa~=4.3
 
 gds-metrics==0.2.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,8 +81,6 @@ phonenumbers==9.0.25
     # via notifications-utils
 prometheus-client==0.24.1
     # via gds-metrics
-pyasn1==0.6.2
-    # via rsa
 pycparser==3.0
     # via cffi
 pypdf==6.7.5
@@ -103,8 +101,6 @@ requests==2.32.5
     # via
     #   govuk-bank-holidays
     #   notifications-utils
-rsa==4.9.1
-    # via -r requirements.in
 s3transfer==0.16.0
     # via boto3
 segno==1.6.6

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -139,10 +139,6 @@ prometheus-client==0.24.1
     # via
     #   -r requirements.txt
     #   gds-metrics
-pyasn1==0.6.2
-    # via
-    #   -r requirements.txt
-    #   rsa
 pycparser==3.0
     # via
     #   -r requirements.txt
@@ -198,8 +194,6 @@ requests==2.32.5
     #   requests-mock
 requests-mock==1.12.1
     # via -r requirements_for_test_common.in
-rsa==4.9.1
-    # via -r requirements.txt
 ruff==0.15.2
     # via -r requirements_for_test_common.in
 s3transfer==0.16.0


### PR DESCRIPTION
Looks like it was introduced as a subdependency here: https://github.com/alphagov/document-download-api/commit/7f5eb371b264c3671a42fc7fa55d7f9c205ec93b#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R35-R54

This is before we were using `pip-compile` so it’s impossible to see what it was a subdependency of.

Anyway it’s not a subdependency of any of our packages now, and we don’t import it in our code.