### PR TITLE
[spike] make processing of jobs with email files more efficient

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -23,6 +23,8 @@ def upload_document(service_id):
         confirmation_email=uploaded_file.confirmation_email,
         retention_period=uploaded_file.retention_period,
         filename=uploaded_file.filename,
+        from_job=uploaded_file.from_job,
+        recipients_csv_link=get_link_to_recipients_csv(uploaded_file.recipients_csv),
     )
 
     return (
@@ -45,4 +47,21 @@ def upload_document(service_id):
             },
         ),
         201,
+    )
+
+
+def get_link_to_recipients_csv(uploaded_file):
+    recipient_csv_upload = document_store.put(
+        uploaded_file.service_id,
+        uploaded_file.recipients_csv,
+        mimetype="text/csv",
+        confirmation_email=None,
+        retention_period=uploaded_file.retention_period,
+    )
+
+    return get_direct_file_url(
+        service_id=uploaded_file.service_id,
+        document_id=recipient_csv_upload["id"],
+        key=recipient_csv_upload["encryption_key"],
+        mimetype="text/csv",
     )

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -23,7 +23,6 @@ def upload_document(service_id):
         confirmation_email=uploaded_file.confirmation_email,
         retention_period=uploaded_file.retention_period,
         filename=uploaded_file.filename,
-        from_job=uploaded_file.from_job,
         recipients_csv_link=get_link_to_recipients_csv(uploaded_file.recipients_csv),
     )
 

--- a/app/utils/file_checks.py
+++ b/app/utils/file_checks.py
@@ -35,13 +35,26 @@ class AntivirusAndMimeTypeCheckError(Exception):
 
 
 class UploadedFile:
-    def __init__(self, *, file_data, is_csv, confirmation_email, retention_period, filename, service_id):
+    def __init__(
+        self,
+        *,
+        file_data,
+        is_csv,
+        confirmation_email,
+        retention_period,
+        filename,
+        service_id,
+        from_job=None,
+        recipients_csv=None,
+    ):
         self.is_csv = is_csv
         self.filename = filename
         self.confirmation_email = confirmation_email
         self.retention_period = retention_period
         self.service_id = service_id
-        self.file_data = file_data
+        self.file_data = (file_data,)
+        from_job = (from_job,)
+        recipients_csv = (recipients_csv,)
 
     @classmethod
     def from_request_json(cls, data, *, service_id):
@@ -63,6 +76,8 @@ class UploadedFile:
             retention_period=data.get("retention_period"),
             filename=data.get("filename", None),
             service_id=service_id,
+            from_job=data.get("from_job"),
+            recipients_csv=data.get("recipients_csv"),
         )
 
     @property
@@ -124,6 +139,14 @@ class UploadedFile:
     def file_data(self, value):
         self._file_data = value
         self.mimetype = self.mimetype_deserialised()
+
+    @property
+    def recipients_csv(self):
+        return self._csv_from_list(self.recipients_csv)
+
+    @property
+    def from_job(self):
+        return self.from_job
 
     @property
     def file_data_hash(self):

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -96,7 +96,16 @@ class DocumentStore:
     @extract_reraise_chained_exception(EventletTimeout)
     @sentry_sdk.trace
     def put(
-        self, service_id, document_stream, *, mimetype, confirmation_email=None, retention_period=None, filename=None
+        self,
+        service_id,
+        document_stream,
+        *,
+        mimetype,
+        confirmation_email=None,
+        retention_period=None,
+        filename=None,
+        from_job=None,
+        recipients_csv_link=None,
     ):
         """
         confirmation_email and retention_period need to already be in a validated and known-good format
@@ -138,6 +147,10 @@ class DocumentStore:
         if filename:
             # Convert utf-8 filenames to ASCII suitable for storing in AWS S3 Metadata.
             extra_kwargs["Metadata"]["filename"] = filename.encode("unicode_escape").decode("ascii")
+
+        if from_job:
+            extra_kwargs["Metadata"]["from_job"] = from_job
+            extra_kwargs["Metadata"]["recipients_csv_link"] = recipients_csv_link
 
         self.s3.put_object(
             Bucket=self.bucket,

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -104,7 +104,6 @@ class DocumentStore:
         confirmation_email=None,
         retention_period=None,
         filename=None,
-        from_job=None,
         recipients_csv_link=None,
     ):
         """
@@ -148,9 +147,8 @@ class DocumentStore:
             # Convert utf-8 filenames to ASCII suitable for storing in AWS S3 Metadata.
             extra_kwargs["Metadata"]["filename"] = filename.encode("unicode_escape").decode("ascii")
 
-        if from_job:
-            extra_kwargs["Metadata"]["from_job"] = from_job
-            extra_kwargs["Metadata"]["recipients_csv_link"] = recipients_csv_link
+        if recipients_csv_link:
+            extra_kwargs["Metadata"]["recipients-csv-link"] = recipients_csv_link
 
         self.s3.put_object(
             Bucket=self.bucket,
@@ -328,14 +326,34 @@ class DocumentStore:
             if e.response["Error"]["Code"] == "404":
                 return False
             raise DocumentStoreError(e.response["Error"]) from e
+        if recipients_csv_link := self.get_recipients_csv_link(s3_response):
+            return self.is_email_address_in_list_of_recipients(self, email_address, recipients_csv_link)
+        else:
+            hashed_email = self.get_email_hash(s3_response)
 
-        hashed_email = self.get_email_hash(s3_response)
+            if not hashed_email:
+                return False
 
-        if not hashed_email:
-            return False
-
-        return self._hasher.verify(value=email_address, hash_to_verify=hashed_email)
+            return self._hasher.verify(value=email_address, hash_to_verify=hashed_email)
 
     @staticmethod
-    def get_email_hash(boto_response):
-        return boto_response.get("Metadata", {}).get("hashed-recipient-email", None)
+    def get_email_hash(s3_response):
+        return s3_response.get("Metadata", {}).get("hashed-recipient-email", None)
+
+    @staticmethod
+    def get_recipients_csv_link(s3_response):
+        return s3_response.get("Metadata", {}).get("recipients-csv-link", None)
+
+    def is_email_address_in_list_of_recipients(self, email_address, recipients_csv_link):
+        recipients_csv = self.get_recipients_csv_from_s3(recipients_csv_link)
+        import csv
+
+        recipients_emails = csv.DictReader(recipients_csv)
+
+        return email_address in recipients_emails
+
+    @staticmethod
+    def get_recipients_csv_from_s3(recipients_csv_link):
+        # TODO: implement this - call self.get(self, service_id, document_id, decryption_key)
+        # get required args from the link
+        pass


### PR DESCRIPTION
This is an illustration of how we could upload just one email file per job, instead of one for each recipient.

This is not a working code, just an illustration.

API part: https://github.com/alphagov/notifications-api/pull/4828