### PR TITLE
Refactor `UploadedFile` to always check file size

### DIFF
--- a/app/utils/file_checks.py
+++ b/app/utils/file_checks.py
@@ -57,7 +57,7 @@ class UploadedFile:
             abort(413)
 
         return cls(
-            file_data=BytesIO(raw_content),
+            file_data=raw_content,
             is_csv=data.get("is_csv"),
             confirmation_email=data.get("confirmation_email"),
             retention_period=data.get("retention_period"),
@@ -118,7 +118,7 @@ class UploadedFile:
 
     @property
     def file_data(self):
-        return self._file_data
+        return BytesIO(self._file_data)
 
     @file_data.setter
     def file_data(self, value):

--- a/app/utils/file_checks.py
+++ b/app/utils/file_checks.py
@@ -53,9 +53,6 @@ class UploadedFile:
         except (binascii.Error, ValueError) as e:
             raise AntivirusAndMimeTypeCheckError("Document is not base64 encoded") from e
 
-        if len(raw_content) > current_app.config["MAX_DECODED_FILE_SIZE"]:
-            abort(413)
-
         return cls(
             file_data=raw_content,
             is_csv=data.get("is_csv"),
@@ -122,6 +119,9 @@ class UploadedFile:
 
     @file_data.setter
     def file_data(self, value):
+        if len(value) > current_app.config["MAX_DECODED_FILE_SIZE"]:
+            abort(413)
+
         self._file_data = value
         self.mimetype = self.mimetype_deserialised()
 


### PR DESCRIPTION
At the moment the file size check is only done when calling the `UploadedFile.from_request_json(…)` class method. If any future code decided to initialise the class directly by calling `UploadedFile(…)` then it would inadvertantly skip the file size check.

By moving the check into the setter method we make sure it’s called however the class is initialised, or if the file data is mutated after initialisation.