### PR TITLE
Reject empty uploads

### DIFF
--- a/app/utils/file_checks.py
+++ b/app/utils/file_checks.py
@@ -121,6 +121,9 @@ class UploadedFile:
         if len(value) > current_app.config["MAX_DECODED_FILE_SIZE"]:
             abort(413)
 
+        if not value:
+            raise AntivirusAndMimeTypeCheckError("Document must not be empty")
+
         self._file_data = value
         self.mimetype = self.mimetype_deserialised()
 

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -414,6 +414,37 @@ def test_document_upload_filename_handling(
     }
 
 
+@pytest.mark.parametrize(
+    "extra_args",
+    (
+        {},
+        {"filename": "example.csv"},
+        {"filename": "example.pdf"},
+        {"is_csv": True},
+        {"is_csv": False},
+        {"is_csv": True, "filename": "example.csv"},
+        {"is_csv": False, "filename": "example.pdf"},
+    ),
+)
+def test_document_upload_empty_file(
+    app,
+    client,
+    store,
+    antivirus,
+    extra_args,
+):
+    response = client.post(
+        "/services/00000000-0000-0000-0000-000000000000/documents",
+        json={
+            "document": base64.b64encode(b"").decode("utf-8"),
+        }
+        | extra_args,
+    )
+
+    assert response.status_code == 400
+    assert response.json == {"error": "Document must not be empty"}
+
+
 def test_document_upload_bad_is_csv_value(client):
     with open(Path(__file__).parent.parent / "sample_files" / "test.csv", "rb") as f:
         response = client.post(


### PR DESCRIPTION
Why do this now? Because we cannot detect the mimetype of an empty file.

However there’s probably no need for people to be sending empty files – in fact it’s most likely testing or a mistake.

Our logs show that this happens fairly infrqeuently, so we don’t think we need to tell users we are doing this in advance.

This is the API counterpart of https://github.com/alphagov/notifications-admin/pull/5963