### PR TITLE
Do not allow files to be uploaded with file types we do not support

### DIFF
--- a/app/utils/file_checks.py
+++ b/app/utils/file_checks.py
@@ -167,6 +167,13 @@ class UploadedFile:
         except (AntivirusError, FiletypeError) as e:
             return {"failure": {"error": e.message, "status_code": e.status_code}}
 
+    def check_mimetype_allowed(self, mimetype):
+        if not is_allowed_mime_type(mimetype):
+            allowed_file_types = ", ".join(sorted({f"'.{x}'" for x in EXTENSIONS}))
+            raise FiletypeError(
+                message=f"Unsupported file type '{mimetype}'. Supported types are: {allowed_file_types}"
+            )
+
     @property
     def _mimetype(self):
         if self.filename:
@@ -178,17 +185,15 @@ class UploadedFile:
                     mimetype,
                     detected_mimetype,
                 )
+                self.check_mimetype_allowed(detected_mimetype)
         else:
             mimetype = get_mime_type(self.file_data)
             # Our mimetype auto-detection sometimes resolves CSV content as text/plain, so we use
             # an explicit POST body parameter `is_csv` from the caller to resolve it as text/csv
             if self.is_csv and mimetype == "text/plain":
                 mimetype = "text/csv"
-        if not is_allowed_mime_type(mimetype):
-            allowed_file_types = ", ".join(sorted({f"'.{x}'" for x in EXTENSIONS}))
-            raise FiletypeError(
-                message=f"Unsupported file type '{mimetype}'. Supported types are: {allowed_file_types}"
-            )
+
+        self.check_mimetype_allowed(mimetype)
         return mimetype
 
     @sentry_sdk.trace

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -26,7 +26,7 @@ def antivirus(mocker):
     )
 
 
-def _document_upload(client, url, file_content, confirmation_email=None, retention_period=None):
+def _document_upload(client, url, file_content, confirmation_email=None, retention_period=None, filename=None):
     data = {
         "document": base64.b64encode(file_content).decode("utf-8"),
     }
@@ -35,9 +35,25 @@ def _document_upload(client, url, file_content, confirmation_email=None, retenti
         data["confirmation_email"] = confirmation_email
     if retention_period:
         data["retention_period"] = retention_period
+    if filename:
+        data["filename"] = filename
 
     response = client.post(url, json=data)
     return response
+
+
+def test_document_upload_magic_type_not_supported(client, antivirus):
+    url = "/services/12345678-1111-1111-1111-123456789012/documents"
+    file_content = b"\x00binary file contents\n"
+
+    response = _document_upload(client, url, file_content, filename="innocuous.txt")
+
+    assert response.status_code == 400
+    assert response.json["error"] == (
+        "Unsupported file type 'application/octet-stream'. "
+        "Supported types are: '.csv', '.doc', '.docx', '.jpeg', '.jpg', '.json', '.odt', '.pdf', '.png', '.rtf', "
+        "'.txt', '.xlsx'"
+    )
 
 
 def test_document_upload_returns_link_to_frontend(client, store, antivirus):


### PR DESCRIPTION
This checks the mime type with libmagic and stops it if it is mimetype we don't
 support.

This is to prevent people uploading potentially malicious files.

Other work has been done to stop people uploading empty files (which show up as a mimetype mismatch too).